### PR TITLE
chore: run knip and sherif in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "main"]
   pull_request:
     branches: ["dev", "main"]
 
@@ -24,6 +24,12 @@ jobs:
 
       - name: Biome check
         run: bun run check
+
+      - name: Knip
+        run: bun run knip
+
+      - name: Sherif
+        run: bun run sherif
 
   build:
     needs: quality


### PR DESCRIPTION
## Summary
- extend frontend CI quality stage to include `bun run knip` and `bun run sherif` in addition to Biome checks
- enable CI push trigger on `main` so direct production fixes are gated by the same quality checks as `dev`

## Validation
- local: `bun run check` passes
- local: `bun run knip` passes
- local: `bun run sherif` passes
- local: `bun run build` passes