### PR TITLE
fix: restore explicit mobile artifact action

### DIFF
--- a/apps/web/src/components/download-sheet.tsx
+++ b/apps/web/src/components/download-sheet.tsx
@@ -42,7 +42,7 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
     reset,
     onArtifactError: setArtifactError,
   });
-  const showWorkingState = isBusy || completion.isCompleting;
+  const showWorkingState = isBusy || completion.isCompleting || completion.awaitingUserAction;
 
   function selectMode(next: DownloadMode) {
     setMode(next);
@@ -113,6 +113,15 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
             immersive={showWorkingState}
             forceWaiting={completion.isCompleting}
           />
+          {completion.awaitingUserAction && (
+            <button
+              type="button"
+              onClick={() => void completion.triggerArtifactOpen()}
+              className="mt-3 w-full rounded-lg bg-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-white"
+            >
+              Save file
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/hooks/use-artifact-download-on-done.ts
+++ b/apps/web/src/hooks/use-artifact-download-on-done.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { isMobileDownloadDevice } from "../lib/ios-device";
 
 type Params = {
   isDone: boolean;
@@ -21,7 +22,9 @@ export function useArtifactDownloadOnDone({
   reset,
   onArtifactError,
 }: Params) {
+  const isMobile = isMobileDownloadDevice();
   const [isCompleting, setIsCompleting] = useState(false);
+  const [awaitingUserAction, setAwaitingUserAction] = useState(false);
   const handledJobIdRef = useRef<string | null>(null);
 
   const completeDownload = useCallback(
@@ -39,17 +42,35 @@ export function useArtifactDownloadOnDone({
   useEffect(() => {
     if (isDone) return;
     setIsCompleting(false);
+    setAwaitingUserAction(false);
   }, [isDone]);
 
   useEffect(() => {
     if (jobId) return;
     handledJobIdRef.current = null;
+    setAwaitingUserAction(false);
   }, [jobId]);
+
+  const triggerArtifactOpen = useCallback(async () => {
+    setIsCompleting(true);
+    setAwaitingUserAction(false);
+    try {
+      await completeDownload(selectedLabel);
+    } catch (error) {
+      setIsCompleting(false);
+      setAwaitingUserAction(true);
+      onArtifactError(error instanceof Error ? error.message : "Download failed");
+    }
+  }, [completeDownload, onArtifactError, selectedLabel]);
 
   useEffect(() => {
     if (!isDone || !jobId) return;
     if (handledJobIdRef.current === jobId) return;
     handledJobIdRef.current = jobId;
+    if (isMobile) {
+      setAwaitingUserAction(true);
+      return;
+    }
     setIsCompleting(true);
     let cancelled = false;
     const run = async () => {
@@ -66,7 +87,7 @@ export function useArtifactDownloadOnDone({
     return () => {
       cancelled = true;
     };
-  }, [completeDownload, isDone, jobId, onArtifactError, selectedLabel]);
+  }, [completeDownload, isDone, isMobile, jobId, onArtifactError, selectedLabel]);
 
-  return { isCompleting };
+  return { isCompleting, awaitingUserAction, triggerArtifactOpen };
 }


### PR DESCRIPTION
## Summary
- restore the explicit mobile `Save file` action after downloader completion so iOS/Android downloads run from a direct user gesture.
- keep desktop auto-download unchanged while preventing the mobile flow from silently failing without visible feedback.

## Included Commits
- 2d82a9c fix: restore explicit mobile artifact action

## Validation
- bun run check
- bun run build