### PR TITLE
fix: restore iOS native prompt and SSE fallback

### DIFF
--- a/apps/web/src/hooks/use-artifact-download-on-done.ts
+++ b/apps/web/src/hooks/use-artifact-download-on-done.ts
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isMobileDownloadDevice } from "../lib/ios-device";
 
+function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException) return error.name === "AbortError";
+  if (error instanceof Error) return error.name === "AbortError";
+  return false;
+}
+
 type Params = {
   isDone: boolean;
   jobId: string | undefined;
@@ -54,9 +60,15 @@ export function useArtifactDownloadOnDone({
   const triggerArtifactOpen = useCallback(async () => {
     setIsCompleting(true);
     setAwaitingUserAction(false);
+    onArtifactError(null);
     try {
       await completeDownload(selectedLabel);
     } catch (error) {
+      if (isAbortError(error)) {
+        setIsCompleting(false);
+        setAwaitingUserAction(true);
+        return;
+      }
       setIsCompleting(false);
       setAwaitingUserAction(true);
       onArtifactError(error instanceof Error ? error.message : "Download failed");

--- a/apps/web/src/hooks/use-downloader-job.ts
+++ b/apps/web/src/hooks/use-downloader-job.ts
@@ -33,7 +33,12 @@ export function useDownloaderJob() {
     return subscribeDownloaderEvents(jobId, {
       onMessage: (next) =>
         setEventJob((current) => (current?.id === next.id ? { ...current, ...next } : next)),
-      onError: () => setSseUnavailable(true),
+      onError: (status) => {
+        if (status === 404) {
+          setSseUnavailable(true);
+          return;
+        }
+      },
     });
   }, [jobId]);
 

--- a/apps/web/src/lib/api-downloader.ts
+++ b/apps/web/src/lib/api-downloader.ts
@@ -5,7 +5,7 @@ import type {
 } from "../types/downloader";
 import { ApiError } from "./api";
 import { API_BASE as BASE } from "./env";
-import { isMobileDownloadDevice } from "./ios-device";
+import { isIosDevice, isMobileDownloadDevice } from "./ios-device";
 
 type ErrorBody = {
   error?: string;
@@ -69,6 +69,40 @@ function filenameFromHeader(contentDisposition: string | null): string | null {
 
 export async function downloadDownloaderArtifact(jobId: string): Promise<void> {
   const endpoint = `${BASE}/downloader/jobs/${encodeURIComponent(jobId)}/artifact`;
+  if (isIosDevice()) {
+    const res = await fetch(endpoint);
+    if (!res.ok) {
+      const body = await readJson(res);
+      throw new ApiError(readErrorMessage(body, "Failed to download artifact"), res.status);
+    }
+    const blob = await res.blob();
+    const fileName =
+      filenameFromHeader(res.headers.get("content-disposition")) ??
+      `typetype-download-${jobId}.${extensionFromType(res.headers.get("content-type"))}`;
+    const share = navigator.share;
+    const canShare = navigator.canShare;
+    if (share && canShare) {
+      const file = new File([blob], fileName, {
+        type: blob.type || "application/octet-stream",
+        lastModified: Date.now(),
+      });
+      if (canShare({ files: [file] })) {
+        await share({ files: [file], title: fileName });
+        return;
+      }
+    }
+    const objectUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = objectUrl;
+    a.download = fileName;
+    a.rel = "noopener";
+    a.target = "_blank";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 10_000);
+    return;
+  }
   if (isMobileDownloadDevice()) {
     window.location.assign(endpoint);
     return;

--- a/apps/web/src/lib/downloader-events.ts
+++ b/apps/web/src/lib/downloader-events.ts
@@ -83,11 +83,11 @@ export function subscribeDownloaderEvents(
   jobId: string,
   handlers: {
     onMessage: (next: DownloaderJobResponse) => void;
-    onError: () => void;
+    onError: (status: number | null) => void;
   },
 ): () => void {
   if (eventsDisabledForSession) {
-    handlers.onError();
+    handlers.onError(404);
     return () => {};
   }
   let closed = false;
@@ -104,10 +104,19 @@ export function subscribeDownloaderEvents(
     }
   };
   eventSource.addEventListener("progress", onProgress);
+  eventSource.addEventListener("open", () => {
+    if (!closed) {
+      eventsDisabledForSession = false;
+    }
+  });
   eventSource.onerror = () => {
     if (closed) return;
-    eventsDisabledForSession = true;
-    handlers.onError();
+    const readyState = eventSource.readyState;
+    const isHardFailure = readyState === EventSource.CLOSED;
+    if (isHardFailure) {
+      eventsDisabledForSession = true;
+    }
+    handlers.onError(isHardFailure ? 404 : null);
     closed = true;
     eventSource.close();
   };


### PR DESCRIPTION
## Summary
- restore iOS downloader behavior to use Safari native share/save prompt from an explicit user gesture, matching the previous reliable flow.
- improve downloader SSE fallback handling so transient event-source failures do not permanently degrade tracking quality, while still falling back on hard 404-style failures.

## Included Commits
- c065196 fix: restore iOS native prompt and SSE fallback

## Validation
- bun run check
- bun run sherif
- bun run knip
- bun run build