### PR TITLE
fix: bind iOS canShare calls to navigator

### DIFF
--- a/apps/web/src/lib/api-downloader.ts
+++ b/apps/web/src/lib/api-downloader.ts
@@ -79,15 +79,13 @@ export async function downloadDownloaderArtifact(jobId: string): Promise<void> {
     const fileName =
       filenameFromHeader(res.headers.get("content-disposition")) ??
       `typetype-download-${jobId}.${extensionFromType(res.headers.get("content-type"))}`;
-    const share = navigator.share;
-    const canShare = navigator.canShare;
-    if (share && canShare) {
+    if (typeof navigator.share === "function" && typeof navigator.canShare === "function") {
       const file = new File([blob], fileName, {
         type: blob.type || "application/octet-stream",
         lastModified: Date.now(),
       });
-      if (canShare({ files: [file] })) {
-        await share({ files: [file], title: fileName });
+      if (navigator.canShare({ files: [file] })) {
+        await navigator.share({ files: [file], title: fileName });
         return;
       }
     }


### PR DESCRIPTION
## Summary
- fix iOS downloader prompt failures by calling `navigator.canShare` and `navigator.share` on the `navigator` instance directly.
- this resolves runtime errors such as `Can only call Navigator.canShare on instance of Navigator` and restores the native iOS share/save prompt flow.

## Included Commits
- a626c51 fix: bind iOS canShare calls to navigator

## Validation
- bun run check
- bun run build