### PR TITLE
fix: auto-start mobile download like desktop

### DIFF
--- a/apps/web/src/components/download-sheet.tsx
+++ b/apps/web/src/components/download-sheet.tsx
@@ -42,7 +42,7 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
     reset,
     onArtifactError: setArtifactError,
   });
-  const showWorkingState = isBusy || completion.isCompleting || completion.awaitingUserAction;
+  const showWorkingState = isBusy || completion.isCompleting;
 
   function selectMode(next: DownloadMode) {
     setMode(next);
@@ -113,15 +113,6 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
             immersive={showWorkingState}
             forceWaiting={completion.isCompleting}
           />
-          {completion.awaitingUserAction && (
-            <button
-              type="button"
-              onClick={() => void completion.triggerArtifactOpen()}
-              className="mt-3 w-full rounded-lg bg-zinc-100 px-3 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-white"
-            >
-              Save file
-            </button>
-          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/hooks/use-artifact-download-on-done.ts
+++ b/apps/web/src/hooks/use-artifact-download-on-done.ts
@@ -1,11 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { isMobileDownloadDevice } from "../lib/ios-device";
-
-function isAbortError(error: unknown): boolean {
-  if (error instanceof DOMException) return error.name === "AbortError";
-  if (error instanceof Error) return error.name === "AbortError";
-  return false;
-}
 
 type Params = {
   isDone: boolean;
@@ -28,9 +21,7 @@ export function useArtifactDownloadOnDone({
   reset,
   onArtifactError,
 }: Params) {
-  const isMobile = isMobileDownloadDevice();
   const [isCompleting, setIsCompleting] = useState(false);
-  const [awaitingUserAction, setAwaitingUserAction] = useState(false);
   const handledJobIdRef = useRef<string | null>(null);
 
   const completeDownload = useCallback(
@@ -48,41 +39,17 @@ export function useArtifactDownloadOnDone({
   useEffect(() => {
     if (isDone) return;
     setIsCompleting(false);
-    setAwaitingUserAction(false);
   }, [isDone]);
 
   useEffect(() => {
     if (jobId) return;
     handledJobIdRef.current = null;
-    setAwaitingUserAction(false);
   }, [jobId]);
-
-  const triggerArtifactOpen = useCallback(async () => {
-    setIsCompleting(true);
-    setAwaitingUserAction(false);
-    onArtifactError(null);
-    try {
-      await completeDownload(selectedLabel);
-    } catch (error) {
-      if (isAbortError(error)) {
-        setIsCompleting(false);
-        setAwaitingUserAction(true);
-        return;
-      }
-      setIsCompleting(false);
-      setAwaitingUserAction(true);
-      onArtifactError(error instanceof Error ? error.message : "Download failed");
-    }
-  }, [completeDownload, onArtifactError, selectedLabel]);
 
   useEffect(() => {
     if (!isDone || !jobId) return;
     if (handledJobIdRef.current === jobId) return;
     handledJobIdRef.current = jobId;
-    if (isMobile) {
-      setAwaitingUserAction(true);
-      return;
-    }
     setIsCompleting(true);
     let cancelled = false;
     const run = async () => {
@@ -99,7 +66,7 @@ export function useArtifactDownloadOnDone({
     return () => {
       cancelled = true;
     };
-  }, [completeDownload, isDone, isMobile, jobId, onArtifactError, selectedLabel]);
+  }, [completeDownload, isDone, jobId, onArtifactError, selectedLabel]);
 
-  return { isCompleting, awaitingUserAction, triggerArtifactOpen };
+  return { isCompleting };
 }

--- a/apps/web/src/lib/api-downloader.ts
+++ b/apps/web/src/lib/api-downloader.ts
@@ -5,7 +5,7 @@ import type {
 } from "../types/downloader";
 import { ApiError } from "./api";
 import { API_BASE as BASE } from "./env";
-import { isIosDevice, isMobileDownloadDevice } from "./ios-device";
+import { isMobileDownloadDevice } from "./ios-device";
 
 type ErrorBody = {
   error?: string;
@@ -69,38 +69,6 @@ function filenameFromHeader(contentDisposition: string | null): string | null {
 
 export async function downloadDownloaderArtifact(jobId: string): Promise<void> {
   const endpoint = `${BASE}/downloader/jobs/${encodeURIComponent(jobId)}/artifact`;
-  if (isIosDevice()) {
-    const res = await fetch(endpoint);
-    if (!res.ok) {
-      const body = await readJson(res);
-      throw new ApiError(readErrorMessage(body, "Failed to download artifact"), res.status);
-    }
-    const blob = await res.blob();
-    const fileName =
-      filenameFromHeader(res.headers.get("content-disposition")) ??
-      `typetype-download-${jobId}.${extensionFromType(res.headers.get("content-type"))}`;
-    if (typeof navigator.share === "function" && typeof navigator.canShare === "function") {
-      const file = new File([blob], fileName, {
-        type: blob.type || "application/octet-stream",
-        lastModified: Date.now(),
-      });
-      if (navigator.canShare({ files: [file] })) {
-        await navigator.share({ files: [file], title: fileName });
-        return;
-      }
-    }
-    const objectUrl = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = objectUrl;
-    a.download = fileName;
-    a.rel = "noopener";
-    a.target = "_blank";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    setTimeout(() => URL.revokeObjectURL(objectUrl), 10_000);
-    return;
-  }
   if (isMobileDownloadDevice()) {
     window.location.assign(endpoint);
     return;


### PR DESCRIPTION
## Summary
- remove the extra mobile `Save file` step and restore automatic artifact handoff after downloader completion, matching desktop behavior.
- keep mobile delivery on native browser handling (`window.location.assign`) to trigger the iOS/Android system prompt without custom share-sheet logic.

## Included Commits
- 2010ddf fix: auto-start mobile download like desktop

## Validation
- bun run check
- bun run sherif
- bun run knip
- bun run build