### PR TITLE
fix: detect iPad desktop-mode as iOS device

### DIFF
--- a/apps/web/src/lib/ios-device.ts
+++ b/apps/web/src/lib/ios-device.ts
@@ -1,6 +1,8 @@
 function isTouchMac(): boolean {
   if (typeof navigator === "undefined") return false;
-  return navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+  const ua = navigator.userAgent;
+  const desktopModeIpad = /Macintosh/.test(ua) && /Mobile\//.test(ua);
+  return desktopModeIpad || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
 }
 
 function isAndroidDevice(): boolean {


### PR DESCRIPTION
## Summary
- treat iPad Safari in desktop-mode user agent (`Macintosh` + `Mobile/`) as iOS so mobile download handling is applied consistently.
- this prevents desktop-style artifact handling from being used on iPad and restores native mobile download prompt behavior.

## Included Commits
- 73aaba7 fix: auto trigger native mobile download prompt

## Validation
- bun run check
- bun run build