### PR TITLE
fix: trigger native iOS download confirmation

### DIFF
--- a/apps/web/src/lib/api-downloader.ts
+++ b/apps/web/src/lib/api-downloader.ts
@@ -70,7 +70,13 @@ function filenameFromHeader(contentDisposition: string | null): string | null {
 export async function downloadDownloaderArtifact(jobId: string): Promise<void> {
   const endpoint = `${BASE}/downloader/jobs/${encodeURIComponent(jobId)}/artifact`;
   if (isMobileDownloadDevice()) {
-    window.location.assign(endpoint);
+    const a = document.createElement("a");
+    a.href = endpoint;
+    a.download = "";
+    a.rel = "noopener";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
     return;
   }
   const res = await fetch(endpoint);


### PR DESCRIPTION
## Summary
- switch mobile artifact handoff to an anchor click with the `download` attribute so iOS Safari shows the native download confirmation popup instead of opening the file viewer.
- keep desktop behavior unchanged while preserving mobile-native download flow.

## Included Commits
- ade3353 fix: trigger native iOS download confirmation

## Validation
- bun run check
- bun run build