### PR TITLE
fix: use preopened iOS tab for download prompt

### DIFF
--- a/apps/web/src/components/download-sheet.tsx
+++ b/apps/web/src/components/download-sheet.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useArtifactDownloadOnDone } from "../hooks/use-artifact-download-on-done";
 import { useDownloaderJob } from "../hooks/use-downloader-job";
 import { useOverlayLock } from "../hooks/use-overlay-lock";
 import { useSmoothDismiss } from "../hooks/use-smooth-dismiss";
+import { cancelPreparedIosArtifactWindow, prepareIosArtifactWindow } from "../lib/api-downloader";
 import type { VideoStream } from "../types/stream";
 import {
   buildDownloaderCreatePayload,
@@ -22,7 +23,8 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
   useOverlayLock(true);
   const { isClosing, dismiss } = useSmoothDismiss({ onClose });
   const downloader = useDownloaderJob();
-  const { isDone, jobId, isQueued, isRunning, errorText, openArtifact, reset, start } = downloader;
+  const { isDone, jobId, isQueued, isRunning, isFailed, errorText, openArtifact, reset, start } =
+    downloader;
   const isBusy = isQueued || isRunning;
   const [artifactError, setArtifactError] = useState<string | null>(null);
   const options = useMemo(() => buildDownloadOptions(stream), [stream]);
@@ -44,6 +46,17 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
   });
   const showWorkingState = isBusy || completion.isCompleting;
 
+  useEffect(() => {
+    if (!isFailed) return;
+    cancelPreparedIosArtifactWindow();
+  }, [isFailed]);
+
+  useEffect(() => {
+    return () => {
+      cancelPreparedIosArtifactWindow();
+    };
+  }, []);
+
   function selectMode(next: DownloadMode) {
     setMode(next);
     const modeOptions = options.filter((option) => option.mode === next);
@@ -53,6 +66,7 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
   function startDownload() {
     if (!selected) return;
     setArtifactError(null);
+    prepareIosArtifactWindow();
     start(buildDownloaderCreatePayload(stream.id, selected));
   }
 

--- a/apps/web/src/hooks/use-downloader-job.ts
+++ b/apps/web/src/hooks/use-downloader-job.ts
@@ -5,7 +5,7 @@ import {
   downloadDownloaderArtifact,
   fetchDownloaderJob,
 } from "../lib/api-downloader";
-import { canUseDownloaderEvents, subscribeDownloaderEvents } from "../lib/downloader-events";
+import { subscribeDownloaderEvents } from "../lib/downloader-events";
 import type {
   DownloaderCreateJobRequest,
   DownloaderJobResponse,
@@ -25,20 +25,11 @@ export function useDownloaderJob() {
 
   useEffect(() => {
     if (!jobId) return;
-    if (!canUseDownloaderEvents()) {
-      setSseUnavailable(true);
-      return;
-    }
     setSseUnavailable(false);
     return subscribeDownloaderEvents(jobId, {
       onMessage: (next) =>
         setEventJob((current) => (current?.id === next.id ? { ...current, ...next } : next)),
-      onError: (status) => {
-        if (status === 404) {
-          setSseUnavailable(true);
-          return;
-        }
-      },
+      onError: () => setSseUnavailable(true),
     });
   }, [jobId]);
 

--- a/apps/web/src/lib/api-downloader.ts
+++ b/apps/web/src/lib/api-downloader.ts
@@ -5,7 +5,9 @@ import type {
 } from "../types/downloader";
 import { ApiError } from "./api";
 import { API_BASE as BASE } from "./env";
-import { isMobileDownloadDevice } from "./ios-device";
+import { isIosDevice, isMobileDownloadDevice } from "./ios-device";
+
+let preparedIosWindow: Window | null = null;
 
 type ErrorBody = {
   error?: string;
@@ -50,6 +52,31 @@ export async function fetchDownloaderJob(jobId: string): Promise<DownloaderJobRe
   return body as DownloaderJobResponse;
 }
 
+export function prepareIosArtifactWindow() {
+  if (!isIosDevice()) return;
+  if (preparedIosWindow && !preparedIosWindow.closed) return;
+  const opened = window.open("about:blank", "_blank");
+  if (!opened) return;
+  opened.document.title = "Preparing download";
+  preparedIosWindow = opened;
+}
+
+export function cancelPreparedIosArtifactWindow() {
+  if (!preparedIosWindow || preparedIosWindow.closed) {
+    preparedIosWindow = null;
+    return;
+  }
+  preparedIosWindow.close();
+  preparedIosWindow = null;
+}
+
+function consumePreparedIosArtifactWindow(): Window | null {
+  const target = preparedIosWindow;
+  preparedIosWindow = null;
+  if (!target || target.closed) return null;
+  return target;
+}
+
 function extensionFromType(contentType: string | null): string {
   const value = contentType ?? "";
   if (value.includes("video/mp4")) return "mp4";
@@ -69,6 +96,13 @@ function filenameFromHeader(contentDisposition: string | null): string | null {
 
 export async function downloadDownloaderArtifact(jobId: string): Promise<void> {
   const endpoint = `${BASE}/downloader/jobs/${encodeURIComponent(jobId)}/artifact`;
+  if (isIosDevice()) {
+    const target = consumePreparedIosArtifactWindow();
+    if (target) {
+      target.location.assign(endpoint);
+      return;
+    }
+  }
   if (isMobileDownloadDevice()) {
     const a = document.createElement("a");
     a.href = endpoint;

--- a/apps/web/src/lib/downloader-events.ts
+++ b/apps/web/src/lib/downloader-events.ts
@@ -1,12 +1,6 @@
 import type { DownloaderJobResponse } from "../types/downloader";
 import { API_BASE as BASE } from "./env";
 
-let eventsDisabledForSession = false;
-
-export function canUseDownloaderEvents(): boolean {
-  return !eventsDisabledForSession;
-}
-
 function toFiniteNumber(value: unknown): number | null {
   if (typeof value !== "number" || !Number.isFinite(value)) return null;
   return value;
@@ -83,13 +77,9 @@ export function subscribeDownloaderEvents(
   jobId: string,
   handlers: {
     onMessage: (next: DownloaderJobResponse) => void;
-    onError: (status: number | null) => void;
+    onError: () => void;
   },
 ): () => void {
-  if (eventsDisabledForSession) {
-    handlers.onError(404);
-    return () => {};
-  }
   let closed = false;
   const url = `${BASE}/downloader/jobs/${encodeURIComponent(jobId)}/events`;
   const eventSource = new EventSource(url, { withCredentials: false });
@@ -104,19 +94,9 @@ export function subscribeDownloaderEvents(
     }
   };
   eventSource.addEventListener("progress", onProgress);
-  eventSource.addEventListener("open", () => {
-    if (!closed) {
-      eventsDisabledForSession = false;
-    }
-  });
   eventSource.onerror = () => {
     if (closed) return;
-    const readyState = eventSource.readyState;
-    const isHardFailure = readyState === EventSource.CLOSED;
-    if (isHardFailure) {
-      eventsDisabledForSession = true;
-    }
-    handlers.onError(isHardFailure ? 404 : null);
+    handlers.onError();
     closed = true;
     eventSource.close();
   };


### PR DESCRIPTION
## Summary
- open a temporary iOS tab during the initial download click and later redirect that tab to the artifact URL when the job completes, so Safari keeps native download UX without a `Save file` step.
- close/cancel the prepared iOS tab on failed jobs or dismissal so abandoned blank tabs are not left behind.
- simplify downloader SSE fallback to per-job fallback behavior, removing session-wide disable logic.

## Included Commits
- 4652644 fix: use preopened iOS tab for download prompt

## Validation
- bun run check
- bun run sherif
- bun run knip
- bun run build