### PR TITLE
fix: simplify mobile artifact handoff after backend fix

### DIFF
--- a/apps/web/src/components/download-sheet.tsx
+++ b/apps/web/src/components/download-sheet.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useArtifactDownloadOnDone } from "../hooks/use-artifact-download-on-done";
 import { useDownloaderJob } from "../hooks/use-downloader-job";
 import { useOverlayLock } from "../hooks/use-overlay-lock";
 import { useSmoothDismiss } from "../hooks/use-smooth-dismiss";
-import { cancelPreparedIosArtifactWindow, prepareIosArtifactWindow } from "../lib/api-downloader";
 import type { VideoStream } from "../types/stream";
 import {
   buildDownloaderCreatePayload,
@@ -23,8 +22,7 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
   useOverlayLock(true);
   const { isClosing, dismiss } = useSmoothDismiss({ onClose });
   const downloader = useDownloaderJob();
-  const { isDone, jobId, isQueued, isRunning, isFailed, errorText, openArtifact, reset, start } =
-    downloader;
+  const { isDone, jobId, isQueued, isRunning, errorText, openArtifact, reset, start } = downloader;
   const isBusy = isQueued || isRunning;
   const [artifactError, setArtifactError] = useState<string | null>(null);
   const options = useMemo(() => buildDownloadOptions(stream), [stream]);
@@ -46,17 +44,6 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
   });
   const showWorkingState = isBusy || completion.isCompleting;
 
-  useEffect(() => {
-    if (!isFailed) return;
-    cancelPreparedIosArtifactWindow();
-  }, [isFailed]);
-
-  useEffect(() => {
-    return () => {
-      cancelPreparedIosArtifactWindow();
-    };
-  }, []);
-
   function selectMode(next: DownloadMode) {
     setMode(next);
     const modeOptions = options.filter((option) => option.mode === next);
@@ -66,7 +53,6 @@ export function DownloadSheet({ stream, onClose, onDone }: Props) {
   function startDownload() {
     if (!selected) return;
     setArtifactError(null);
-    prepareIosArtifactWindow();
     start(buildDownloaderCreatePayload(stream.id, selected));
   }
 

--- a/apps/web/src/lib/api-downloader.ts
+++ b/apps/web/src/lib/api-downloader.ts
@@ -5,9 +5,7 @@ import type {
 } from "../types/downloader";
 import { ApiError } from "./api";
 import { API_BASE as BASE } from "./env";
-import { isIosDevice, isMobileDownloadDevice } from "./ios-device";
-
-let preparedIosWindow: Window | null = null;
+import { isMobileDownloadDevice } from "./ios-device";
 
 type ErrorBody = {
   error?: string;
@@ -52,41 +50,6 @@ export async function fetchDownloaderJob(jobId: string): Promise<DownloaderJobRe
   return body as DownloaderJobResponse;
 }
 
-export function prepareIosArtifactWindow() {
-  if (!isIosDevice()) return;
-  if (preparedIosWindow && !preparedIosWindow.closed) return;
-  const opened = window.open("about:blank", "_blank");
-  if (!opened) return;
-  opened.document.title = "Preparing download";
-  preparedIosWindow = opened;
-}
-
-export function cancelPreparedIosArtifactWindow() {
-  if (!preparedIosWindow || preparedIosWindow.closed) {
-    preparedIosWindow = null;
-    return;
-  }
-  preparedIosWindow.close();
-  preparedIosWindow = null;
-}
-
-function consumePreparedIosArtifactWindow(): Window | null {
-  const target = preparedIosWindow;
-  preparedIosWindow = null;
-  if (!target || target.closed) return null;
-  return target;
-}
-
-function clickDownloadAnchor(doc: Document, href: string) {
-  const a = doc.createElement("a");
-  a.href = href;
-  a.download = "";
-  a.rel = "noopener";
-  doc.body.appendChild(a);
-  a.click();
-  doc.body.removeChild(a);
-}
-
 function extensionFromType(contentType: string | null): string {
   const value = contentType ?? "";
   if (value.includes("video/mp4")) return "mp4";
@@ -106,33 +69,8 @@ function filenameFromHeader(contentDisposition: string | null): string | null {
 
 export async function downloadDownloaderArtifact(jobId: string): Promise<void> {
   const endpoint = `${BASE}/downloader/jobs/${encodeURIComponent(jobId)}/artifact`;
-  if (isIosDevice()) {
-    const target = consumePreparedIosArtifactWindow();
-    if (target) {
-      try {
-        const doc = target.document;
-        doc.open();
-        doc.write(
-          "<!doctype html><html><head><title>Preparing download</title></head><body></body></html>",
-        );
-        doc.close();
-        clickDownloadAnchor(doc, endpoint);
-        return;
-      } catch {
-        target.location.assign(endpoint);
-        return;
-      }
-    }
-    try {
-      clickDownloadAnchor(document, endpoint);
-      return;
-    } catch {
-      window.location.assign(endpoint);
-      return;
-    }
-  }
   if (isMobileDownloadDevice()) {
-    clickDownloadAnchor(document, endpoint);
+    window.location.assign(endpoint);
     return;
   }
   const res = await fetch(endpoint);


### PR DESCRIPTION
## Summary
- remove frontend iOS temporary-tab/download-anchor workarounds now that backend artifact responses enforce strict download headers for Safari.
- restore a simple mobile flow (`window.location.assign`) and keep desktop blob download behavior unchanged.

## Included Commits
- 3bd51cc fix: simplify mobile artifact handoff after backend fix

## Validation
- bun run check
- bun run sherif
- bun run knip
- bun run build