### PR TITLE
refactor: migrate frontend auth to cookie refresh contract

### DIFF
--- a/apps/web/src/components/navbar-account-controls.tsx
+++ b/apps/web/src/components/navbar-account-controls.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { logoutSession } from "../lib/auth-session";
 import { goto } from "../lib/route-redirect";
 import type { AuthMe, AuthStatus } from "../types/auth";
 import { ProfileAvatar } from "./profile-avatar";
@@ -38,6 +39,11 @@ export function NavbarAccountControls({
   signOut,
 }: Props) {
   const profileName = me?.publicUsername?.trim() ? me.publicUsername : null;
+
+  async function handleSignOut() {
+    await logoutSession();
+    signOut();
+  }
 
   if (isMobile) {
     if (!isAuthed || isGuest || !me) {
@@ -150,7 +156,7 @@ export function NavbarAccountControls({
           )}
           <button
             type="button"
-            onClick={signOut}
+            onClick={() => void handleSignOut()}
             className="h-8 px-3 text-xs rounded-full bg-surface-strong hover:bg-surface-soft text-fg"
           >
             Sign out

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -3,6 +3,7 @@ import { siBilibili, siNiconico, siYoutube } from "simple-icons";
 import { useAuth } from "../hooks/use-auth";
 import { useMobile } from "../hooks/use-mobile";
 import { useSettings } from "../hooks/use-settings";
+import { logoutSession } from "../lib/auth-session";
 import { useUiStore } from "../stores/ui-store";
 import type { ServiceId } from "../types/user";
 import { NAV_ITEMS } from "./nav-items";
@@ -141,6 +142,7 @@ export function Sidebar() {
             <button
               type="button"
               onClick={() => {
+                void logoutSession();
                 signOut();
                 closeMobileSidebar();
               }}

--- a/apps/web/src/lib/api-auth.ts
+++ b/apps/web/src/lib/api-auth.ts
@@ -19,9 +19,9 @@ type RegisterPayload = {
 
 async function parseAuthResponse(res: Response): Promise<AuthResponse> {
   const body = normalizeApiPayload(
-    await res.json().catch(() => ({ token: "" })),
+    await res.json().catch(() => ({ accessToken: "" })),
   ) as Partial<AuthResponse>;
-  if (!res.ok || typeof body.token !== "string" || body.token.length === 0) {
+  if (!res.ok || typeof body.accessToken !== "string" || body.accessToken.length === 0) {
     recordApiError({
       endpoint: "/auth",
       status: res.status,
@@ -36,7 +36,7 @@ async function parseAuthResponse(res: Response): Promise<AuthResponse> {
     });
     throw new ApiError("Authentication failed", res.status);
   }
-  return { token: body.token };
+  return { accessToken: body.accessToken };
 }
 
 async function authedJson<T>(url: string, token: string): Promise<T> {
@@ -97,6 +97,7 @@ export async function registerAuth(payload: RegisterPayload): Promise<AuthRespon
   const res = await fetch(`${BASE}/auth/register`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify(payload),
   });
   return parseAuthResponse(res);
@@ -106,18 +107,30 @@ export async function loginAuth(payload: LoginPayload): Promise<AuthResponse> {
   const res = await fetch(`${BASE}/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify(payload),
   });
   return parseAuthResponse(res);
 }
 
-export async function refreshAuth(token: string): Promise<AuthResponse> {
+export async function refreshAuth(): Promise<AuthResponse> {
   const res = await fetch(`${BASE}/auth/refresh`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ token }),
+    credentials: "include",
+    body: JSON.stringify({}),
   });
   return parseAuthResponse(res);
+}
+
+export async function logoutAuth(): Promise<void> {
+  const res = await fetch(`${BASE}/auth/logout`, {
+    method: "POST",
+    credentials: "include",
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new ApiError("Logout failed", res.status);
+  }
 }
 
 export async function resetPassword(payload: {

--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -1,7 +1,7 @@
 import { useAuthStore } from "../stores/auth-store";
 import type { AuthMe } from "../types/auth";
 import { ApiError } from "./api";
-import { fetchMe, loginAuth, refreshAuth, registerAuth } from "./api-auth";
+import { fetchMe, loginAuth, logoutAuth, refreshAuth, registerAuth } from "./api-auth";
 
 type Credentials = {
   identifier: string;
@@ -21,11 +21,9 @@ async function hydrateSession(token: string): Promise<AuthMe> {
 }
 
 export async function refreshSession(): Promise<string> {
-  const token = useAuthStore.getState().token;
-  if (!token) throw new ApiError("Authentication required", 401);
-  const refreshed = await refreshAuth(token);
-  await hydrateSession(refreshed.token);
-  return refreshed.token;
+  const refreshed = await refreshAuth();
+  await hydrateSession(refreshed.accessToken);
+  return refreshed.accessToken;
 }
 
 export async function bootstrapSession(): Promise<void> {
@@ -54,10 +52,20 @@ export async function bootstrapSession(): Promise<void> {
 
 export async function loginSession(payload: Credentials): Promise<void> {
   const response = await loginAuth(payload);
-  await hydrateSession(response.token);
+  await hydrateSession(response.accessToken);
 }
 
 export async function registerSession(payload: RegisterPayload): Promise<void> {
   const response = await registerAuth(payload);
-  await hydrateSession(response.token);
+  await hydrateSession(response.accessToken);
+}
+
+export async function logoutSession(): Promise<void> {
+  try {
+    await logoutAuth();
+  } catch {
+    useAuthStore.getState().setSignedOut();
+    return;
+  }
+  useAuthStore.getState().setSignedOut();
 }

--- a/apps/web/src/lib/authed.ts
+++ b/apps/web/src/lib/authed.ts
@@ -13,18 +13,23 @@ function withBearer(init: RequestInit | undefined, token: string): RequestInit {
 }
 
 export async function authed(url: string, init?: RequestInit): Promise<Response> {
-  const token = useAuthStore.getState().token;
   const method = init?.method ?? "GET";
   const path = sanitizeRequestPath(url);
+  let token = useAuthStore.getState().token;
   if (!token) {
-    recordApiError({
-      endpoint: url,
-      status: 401,
-      code: "AUTH_REQUIRED",
-      message: "Authentication required",
-    });
-    recordClientEvent("auth.missing_token", { method, path });
-    throw new ApiError("Authentication required", 401);
+    recordClientEvent("auth.missing_token_try_refresh", { method, path });
+    try {
+      token = await refreshSession();
+    } catch {
+      useAuthStore.getState().setSignedOut();
+      recordApiError({
+        endpoint: url,
+        status: 401,
+        code: "AUTH_REQUIRED",
+        message: "Authentication required",
+      });
+      throw new ApiError("Authentication required", 401);
+    }
   }
   let res: Response;
   try {

--- a/apps/web/src/lib/recommendation-tracker.ts
+++ b/apps/web/src/lib/recommendation-tracker.ts
@@ -1,6 +1,7 @@
 import { useAuthStore } from "../stores/auth-store";
 import { useRecommendationTrackingStore } from "../stores/recommendation-tracking-store";
 import type { VideoStream } from "../types/stream";
+import { refreshSession } from "./auth-session";
 import { API_BASE as BASE } from "./env";
 
 type RecommendationEventType = "impression" | "click" | "watch" | "favorite" | "watch_later_add";
@@ -34,17 +35,26 @@ function trackingEnabled(): boolean {
 function post(path: string, payload: Record<string, unknown>) {
   if (typeof window === "undefined") return;
   if (!trackingEnabled()) return;
-  const token = useAuthStore.getState().token;
-  if (!token) return;
-  void fetch(`${BASE}${path}`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-    keepalive: true,
-  }).catch(() => {
+  const send = async () => {
+    let token = useAuthStore.getState().token;
+    if (!token) {
+      try {
+        token = await refreshSession();
+      } catch {
+        return;
+      }
+    }
+    await fetch(`${BASE}${path}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  };
+  void send().catch(() => {
     return;
   });
 }

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -13,7 +13,7 @@ export type AuthMe = {
 export type AuthStatus = "loading" | "authenticated" | "guest" | "signed_out";
 
 export type AuthResponse = {
-  token: string;
+  accessToken: string;
 };
 
 export type AuthUser = {


### PR DESCRIPTION
## Summary
- migrate frontend auth parsing and session hydration to the new backend contract that returns `accessToken`, and refresh sessions through cookie-based `/auth/refresh` without sending legacy body tokens.
- ensure authenticated API calls can recover from missing in-memory tokens by attempting refresh first, then fail signed-out if refresh is not possible.
- route sign-out and recommendation tracking through the refreshed auth path so logout clears server refresh cookie state and tracker calls remain authenticated after reloads.

## Included Commits
- 13e7b75 fix: route logout and tracker calls through refreshed auth
- 1d4a6c6 refactor: align auth session flow with cookie refresh contract

## Validation
- bun run check
- bun run sherif
- bun run knip
- bun run build
- local runtime smoke: register -> refresh(cookie) -> me -> logout -> refresh 401