### PR TITLE
fix: harden auth refresh flow and watch progress resume

### DIFF
--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -9,6 +9,7 @@ export function useAuth() {
 
   const role = me?.role ?? null;
   const isAuthed = token !== null;
+  const authReady = status !== "loading";
   const isGuest = status === "guest";
   const publicUsername = me?.publicUsername ?? null;
   const bio = me?.bio ?? null;
@@ -23,6 +24,7 @@ export function useAuth() {
     token,
     me,
     role,
+    authReady,
     publicUsername,
     bio,
     avatarUrl,

--- a/apps/web/src/hooks/use-blocked.ts
+++ b/apps/web/src/hooks/use-blocked.ts
@@ -26,14 +26,18 @@ type BlockVideoArgs = {
 
 export function useBlocked() {
   const qc = useQueryClient();
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
 
   const channels = useQuery({
     queryKey: CHANNELS_KEY,
     queryFn: fetchBlockedChannels,
-    enabled: isAuthed,
+    enabled: authReady && isAuthed,
   });
-  const videos = useQuery({ queryKey: VIDEOS_KEY, queryFn: fetchBlockedVideos, enabled: isAuthed });
+  const videos = useQuery({
+    queryKey: VIDEOS_KEY,
+    queryFn: fetchBlockedVideos,
+    enabled: authReady && isAuthed,
+  });
 
   const addChannel = useMutation({
     mutationFn: ({ url, name, thumbnailUrl, global }: BlockChannelArgs) =>

--- a/apps/web/src/hooks/use-history.ts
+++ b/apps/web/src/hooks/use-history.ts
@@ -10,7 +10,7 @@ const historyKey = (q: string) => ["history", q];
 
 export function useHistory(searchQuery = "") {
   const qc = useQueryClient();
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
   const debouncedQuery = useDebouncedValue(searchQuery, 300);
 
   const query = useInfiniteQuery({
@@ -26,7 +26,7 @@ export function useHistory(searchQuery = "") {
       return fetched < lastPage.total ? fetched : undefined;
     },
     initialPageParam: 0,
-    enabled: isAuthed,
+    enabled: authReady && isAuthed,
   });
 
   const add = useMutation({

--- a/apps/web/src/hooks/use-home-recommendations.ts
+++ b/apps/web/src/hooks/use-home-recommendations.ts
@@ -18,7 +18,7 @@ type Result = {
 };
 
 export function useHomeRecommendations(): Result {
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
   const { settings } = useSettings();
   const intent: RecommendationIntent = "auto";
   const query = useInfiniteQuery({
@@ -32,7 +32,7 @@ export function useHomeRecommendations(): Result {
       ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (last) => (last.hasMore ? (last.nextCursor ?? undefined) : undefined),
-    enabled: isAuthed,
+    enabled: authReady && isAuthed,
     staleTime: 90 * 1000,
   });
 

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -12,8 +12,8 @@ const PAGE_SIZE = 20;
 
 export function useNotifications(open: boolean) {
   const qc = useQueryClient();
-  const { isAuthed, isGuest } = useAuth();
-  const enabled = isAuthed && !isGuest;
+  const { authReady, isAuthed, isGuest } = useAuth();
+  const enabled = authReady && isAuthed && !isGuest;
 
   const unreadQuery = useQuery({
     queryKey: UNREAD_KEY,

--- a/apps/web/src/hooks/use-playlists.ts
+++ b/apps/web/src/hooks/use-playlists.ts
@@ -28,9 +28,13 @@ type RemoveVideoPayload = {
 
 export function usePlaylists() {
   const qc = useQueryClient();
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
 
-  const query = useQuery({ queryKey: KEY, queryFn: fetchPlaylists, enabled: isAuthed });
+  const query = useQuery({
+    queryKey: KEY,
+    queryFn: fetchPlaylists,
+    enabled: authReady && isAuthed,
+  });
 
   const create = useMutation({
     mutationFn: (name: string) =>

--- a/apps/web/src/hooks/use-progress.ts
+++ b/apps/web/src/hooks/use-progress.ts
@@ -3,21 +3,21 @@ import { fetchProgress, updateProgress } from "../lib/api-collections";
 import { useAuth } from "./use-auth";
 
 export function useProgress(videoUrl: string) {
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
   return useQuery({
     queryKey: ["progress", videoUrl],
     queryFn: () =>
       isAuthed ? fetchProgress(videoUrl) : Promise.resolve({ videoUrl, position: 0, updatedAt: 0 }),
     retry: false,
     staleTime: Infinity,
-    enabled: videoUrl.length > 0,
+    enabled: authReady && videoUrl.length > 0,
   });
 }
 
 export function useSaveProgress(videoUrl: string) {
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
   return useMutation({
     mutationFn: (position: number) =>
-      isAuthed ? updateProgress(videoUrl, position) : Promise.resolve(),
+      authReady && isAuthed ? updateProgress(videoUrl, position) : Promise.resolve(),
   });
 }

--- a/apps/web/src/hooks/use-search-history.ts
+++ b/apps/web/src/hooks/use-search-history.ts
@@ -7,7 +7,7 @@ const PAGE_SIZE = 8;
 
 export function useSearchHistory() {
   const qc = useQueryClient();
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
   const query = useInfiniteQuery({
     queryKey: KEY,
     queryFn: ({ pageParam = 1 }) => fetchSearchHistoryPage(pageParam, PAGE_SIZE),
@@ -16,7 +16,7 @@ export function useSearchHistory() {
       return loaded < lastPage.total ? lastPage.page + 1 : undefined;
     },
     initialPageParam: 1,
-    enabled: isAuthed,
+    enabled: authReady && isAuthed,
     gcTime: 0,
   });
 

--- a/apps/web/src/hooks/use-settings.ts
+++ b/apps/web/src/hooks/use-settings.ts
@@ -22,13 +22,13 @@ const DEFAULTS: SettingsItem = {
 
 export function useSettings() {
   const qc = useQueryClient();
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
   const setTrackingEnabled = useRecommendationTrackingStore((s) => s.setEnabled);
 
   const query = useQuery({
     queryKey: KEY,
     queryFn: () => fetchSettings(),
-    enabled: isAuthed,
+    enabled: authReady && isAuthed,
     placeholderData: DEFAULTS,
   });
 

--- a/apps/web/src/hooks/use-shorts-feed.ts
+++ b/apps/web/src/hooks/use-shorts-feed.ts
@@ -28,7 +28,7 @@ type ShortsFeed = {
 const SHORTS_QUERY = "shorts";
 
 export function useShortsFeed(): ShortsFeed {
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
   const { settings } = useSettings();
   const { filter } = useBlockedFilter();
   const hiddenVideoIds = useShortsFeedbackStore((s) => s.hiddenVideoIds);
@@ -46,7 +46,7 @@ export function useShortsFeed(): ShortsFeed {
       ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (last) => (last.hasMore ? (last.nextCursor ?? undefined) : undefined),
-    enabled: isAuthed,
+    enabled: authReady && isAuthed,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -59,7 +59,7 @@ export function useShortsFeed(): ShortsFeed {
       fetchSubscriptionShorts(pageParam as number, 30, settings.defaultService, true),
     initialPageParam: 0,
     getNextPageParam: (last) => parseNextPage(last.nextpage),
-    enabled: isAuthed && recommendations.isSuccess && !hasRecommendationShorts,
+    enabled: authReady && isAuthed && recommendations.isSuccess && !hasRecommendationShorts,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -69,7 +69,7 @@ export function useShortsFeed(): ShortsFeed {
       fetchSearch(SHORTS_QUERY, settings.defaultService, pageParam as string | undefined),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (last) => last.nextpage ?? undefined,
-    enabled: !isAuthed,
+    enabled: authReady && !isAuthed,
     staleTime: 90 * 1000,
   });
 
@@ -98,7 +98,7 @@ export function useShortsFeed(): ShortsFeed {
     hiddenChannelUrls,
   ]);
 
-  const useRecommendations = isAuthed && hasRecommendationShorts;
+  const useRecommendations = authReady && isAuthed && hasRecommendationShorts;
   return {
     shorts,
     isLoading:

--- a/apps/web/src/hooks/use-subscription-feed.ts
+++ b/apps/web/src/hooks/use-subscription-feed.ts
@@ -15,7 +15,7 @@ type Result = {
 };
 
 export function useSubscriptionFeed(): Result {
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
   const { query: subsQuery } = useSubscriptions();
   const avatarMap = new Map(
     (subsQuery.data ?? []).map((s) => [s.channelUrl, proxyImage(s.avatarUrl)]),
@@ -27,7 +27,7 @@ export function useSubscriptionFeed(): Result {
     initialPageParam: 0,
     getNextPageParam: (last, pages) => (last.nextpage !== null ? pages.length : undefined),
     staleTime: 5 * 60 * 1000,
-    enabled: isAuthed,
+    enabled: authReady && isAuthed,
   });
 
   const streams = (query.data?.pages ?? [])

--- a/apps/web/src/hooks/use-subscriptions.ts
+++ b/apps/web/src/hooks/use-subscriptions.ts
@@ -25,12 +25,12 @@ function dedupeSubscriptions(data: SubscriptionItem[]): SubscriptionItem[] {
 
 export function useSubscriptions() {
   const qc = useQueryClient();
-  const { isAuthed } = useAuth();
+  const { authReady, isAuthed } = useAuth();
 
   const query = useQuery({
     queryKey: KEY,
     queryFn: fetchSubscriptions,
-    enabled: isAuthed,
+    enabled: authReady && isAuthed,
     select: dedupeSubscriptions,
   });
 

--- a/apps/web/src/hooks/use-watch-progress-persistence.ts
+++ b/apps/web/src/hooks/use-watch-progress-persistence.ts
@@ -11,17 +11,21 @@ type Args = {
 
 export function useWatchProgressPersistence({ durationSec, isLive, mutate }: Args) {
   const positionRef = useRef(0);
+  const lastSavedPositionRef = useRef(0);
   const mutateRef = useRef(mutate);
   mutateRef.current = mutate;
   const isIos = isIosDevice();
 
   const saveRef = useRef<(seeked: boolean) => void>(() => {});
   saveRef.current = (seeked: boolean) => {
-    const positionMs = positionRef.current;
+    const positionMs = Math.max(0, Math.round(positionRef.current));
     const durationMs = durationSec * 1000;
+    if (!Number.isFinite(positionMs) || positionMs <= 0) return;
     if (positionMs >= durationMs * 0.95) return;
-    if (!seeked && positionMs < 5000) return;
-    mutateRef.current(seeked && positionMs < 5000 ? 0 : positionMs);
+    if (positionMs < 5000) return;
+    if (!seeked && positionMs < lastSavedPositionRef.current) return;
+    lastSavedPositionRef.current = positionMs;
+    mutateRef.current(positionMs);
   };
 
   const handleTimeUpdate = useCallback((positionMs: number) => {

--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -14,16 +14,26 @@ type RegisterPayload = {
   name: string;
 };
 
+let refreshInFlight: Promise<string> | null = null;
+
 async function hydrateSession(token: string): Promise<AuthMe> {
   const me = await fetchMe(token);
   useAuthStore.getState().setSession(token, me);
   return me;
 }
 
-export async function refreshSession(): Promise<string> {
+async function runRefreshSession(): Promise<string> {
   const refreshed = await refreshAuth();
   await hydrateSession(refreshed.accessToken);
   return refreshed.accessToken;
+}
+
+export async function refreshSession(): Promise<string> {
+  if (refreshInFlight) return refreshInFlight;
+  refreshInFlight = runRefreshSession().finally(() => {
+    refreshInFlight = null;
+  });
+  return refreshInFlight;
 }
 
 export async function bootstrapSession(): Promise<void> {

--- a/apps/web/src/routes/watch.tsx
+++ b/apps/web/src/routes/watch.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { lazy, Suspense, useEffect, useRef } from "react";
 import { PageSpinner } from "../components/page-spinner";
 import { StreamError } from "../components/stream-error";
+import { useAuth } from "../hooks/use-auth";
 import { useHistory } from "../hooks/use-history";
 import { useProgress } from "../hooks/use-progress";
 import {
@@ -31,6 +32,7 @@ function PlayerOnlyLoader() {
 
 function WatchPage() {
   const { v } = Route.useSearch();
+  const { authReady, isAuthed } = useAuth();
   const { data: stream, isLoading, isError, error, refetch } = useStream(v);
   const { add } = useHistory();
   const progressFetch = useProgress(v);
@@ -53,6 +55,7 @@ function WatchPage() {
   }, [stream]);
 
   if (isLoading) return <PlayerOnlyLoader />;
+  if (authReady && isAuthed && progressFetch.isPending) return <PlayerOnlyLoader />;
 
   if (isError || !stream) {
     const genericExtractorError =

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -56,8 +56,7 @@ const stored = readStoredAuth();
 export const useAuthStore = create<AuthStore>((set) => ({
   token: stored?.token ?? null,
   me: stored?.me ?? null,
-  status:
-    stored?.token == null ? "signed_out" : stored.me == null ? "loading" : toStatus(stored.me),
+  status: stored?.token == null ? "signed_out" : "loading",
   setBootstrapping: () =>
     set((state) => ({
       ...state,


### PR DESCRIPTION
## Summary
- harden frontend auth handling with single-flight refresh and `authReady` gating so protected queries wait for session bootstrap and no longer race refresh calls.
- stabilize watch resume persistence by preventing low/retrograde progress writes and waiting for authenticated progress fetch before mounting player start position.
- keep protected feature hooks aligned with the new cookie refresh contract by requiring ready authenticated state before firing server-state queries.

## Included Commits
- da42f8e fix: avoid watch progress resets to start position
- a08a1a8 fix: serialize auth refresh and gate protected queries

## Validation
- bun run check
- bun run sherif
- bun run knip
- bun run build