### PR TITLE
fix: enforce original audio fallback and player menu scrollbars

### DIFF
--- a/apps/web/src/components/audio-track-selector.tsx
+++ b/apps/web/src/components/audio-track-selector.tsx
@@ -9,6 +9,8 @@ import {
 } from "../lib/vidstack";
 
 const languageIcon: DefaultLayoutIcon = (props) => <LanguageIcon {...props} />;
+const MENU_ITEMS_CLASS =
+  "vds-menu-items overflow-y-auto overscroll-y-contain pr-0.5 [scrollbar-width:thin] [scrollbar-color:var(--color-zinc-500)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-surface-soft/80 [&::-webkit-scrollbar-thumb:hover]:bg-surface-soft [&::-webkit-scrollbar-track]:bg-transparent";
 
 type Props = {
   originalLocale?: string | null;
@@ -49,7 +51,7 @@ export function AudioTrackSelector({ originalLocale }: Props) {
   return (
     <Menu.Root ref={menuRef} className="vds-audio-menu vds-menu">
       <DefaultMenuButton label="Language" hint={currentHint} Icon={languageIcon} />
-      <Menu.Items className="vds-menu-items">
+      <Menu.Items className={MENU_ITEMS_CLASS}>
         <DefaultMenuRadioGroup value={selectedValue} options={radioOptions} onChange={onChange} />
       </Menu.Items>
     </Menu.Root>

--- a/apps/web/src/components/format-selector.tsx
+++ b/apps/web/src/components/format-selector.tsx
@@ -12,6 +12,8 @@ const FORMAT_OPTIONS: { label: string; value: "H.264" | "VP9" }[] = [
   { label: "H.264", value: "H.264" },
   { label: "VP9", value: "VP9" },
 ];
+const MENU_ITEMS_CLASS =
+  "vds-menu-items overflow-y-auto overscroll-y-contain pr-0.5 [scrollbar-width:thin] [scrollbar-color:var(--color-zinc-500)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-surface-soft/80 [&::-webkit-scrollbar-thumb:hover]:bg-surface-soft [&::-webkit-scrollbar-track]:bg-transparent";
 
 export function FormatSelector() {
   const menuRef = useRef<MenuInstance>(null);
@@ -34,7 +36,7 @@ export function FormatSelector() {
   return (
     <Menu.Root ref={menuRef} className="vds-format-menu vds-menu">
       <DefaultMenuButton label="Format" hint={current} />
-      <Menu.Items className="vds-menu-items">
+      <Menu.Items className={MENU_ITEMS_CLASS}>
         <DefaultMenuRadioGroup value={current} options={availableOptions} onChange={onChange} />
       </Menu.Items>
     </Menu.Root>

--- a/apps/web/src/components/player-internals.tsx
+++ b/apps/web/src/components/player-internals.tsx
@@ -82,6 +82,8 @@ type PlayerDefaultsProps = {
   defaultQuality?: string;
   defaultAudioLanguage?: string;
   preferOriginalLanguage?: boolean;
+  requireOriginalLanguage?: boolean;
+  onOriginalLanguageUnavailable?: () => void;
   originalAudioLocale?: string | null;
   subtitlesEnabled?: boolean;
   defaultSubtitleLanguage?: string;
@@ -91,6 +93,8 @@ export function PlayerDefaults({
   defaultQuality,
   defaultAudioLanguage,
   preferOriginalLanguage,
+  requireOriginalLanguage,
+  onOriginalLanguageUnavailable,
   originalAudioLocale,
   subtitlesEnabled,
   defaultSubtitleLanguage,
@@ -102,6 +106,7 @@ export function PlayerDefaults({
   const qualityApplied = useRef(false);
   const audioApplied = useRef(false);
   const subtitleApplied = useRef(false);
+  const originalMissingNotified = useRef(false);
 
   const preferredTag = normalizeLanguageTag(defaultAudioLanguage);
   const originalTag = normalizeLanguageTag(originalAudioLocale);
@@ -117,15 +122,36 @@ export function PlayerDefaults({
 
   useEffect(() => {
     if (!canPlay || audioApplied.current || audioOptions.length === 0) return;
-    const match = preferOriginalLanguage
+    const forceOriginal = requireOriginalLanguage || preferOriginalLanguage;
+    let match = forceOriginal
       ? (audioOptions.find((option) => includesOriginal(option.label)) ??
         audioOptions.find((option) => normalizeLanguageTag(option.track.language) === originalTag))
-      : audioOptions.find((option) => normalizeLanguageTag(option.track.language) === preferredTag);
+      : undefined;
+    if (!match && forceOriginal && !originalMissingNotified.current) {
+      originalMissingNotified.current = true;
+      onOriginalLanguageUnavailable?.();
+    }
+    if (!match) {
+      match = audioOptions.find(
+        (option) => normalizeLanguageTag(option.track.language) === preferredTag,
+      );
+    }
+    if (!match) {
+      match = audioOptions[0];
+    }
     if (match) {
       match.select();
       audioApplied.current = true;
     }
-  }, [canPlay, audioOptions, preferOriginalLanguage, originalTag, preferredTag]);
+  }, [
+    canPlay,
+    audioOptions,
+    preferOriginalLanguage,
+    requireOriginalLanguage,
+    originalTag,
+    preferredTag,
+    onOriginalLanguageUnavailable,
+  ]);
 
   useEffect(() => {
     if (!canPlay || subtitleApplied.current || !subtitlesEnabled) return;

--- a/apps/web/src/components/quality-selector.tsx
+++ b/apps/web/src/components/quality-selector.tsx
@@ -10,6 +10,8 @@ import {
 } from "../lib/vidstack";
 
 const qualityIcon: DefaultLayoutIcon = (props) => <ClipIcon {...props} />;
+const MENU_ITEMS_CLASS =
+  "vds-menu-items overflow-y-auto overscroll-y-contain pr-0.5 [scrollbar-width:thin] [scrollbar-color:var(--color-zinc-500)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-surface-soft/80 [&::-webkit-scrollbar-thumb:hover]:bg-surface-soft [&::-webkit-scrollbar-track]:bg-transparent";
 
 export function QualitySelector() {
   const menuRef = useRef<MenuInstance>(null);
@@ -37,7 +39,7 @@ export function QualitySelector() {
   return (
     <Menu.Root ref={menuRef} className="vds-quality-menu vds-menu">
       <DefaultMenuButton label="Quality" hint={current} Icon={qualityIcon} />
-      <Menu.Items className="vds-menu-items">
+      <Menu.Items className={MENU_ITEMS_CLASS}>
         <DefaultMenuRadioGroup value={current ?? ""} options={radioOptions} onChange={onChange} />
       </Menu.Items>
     </Menu.Root>

--- a/apps/web/src/components/shorts-video-player.tsx
+++ b/apps/web/src/components/shorts-video-player.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { isIosDevice } from "../lib/ios-device";
 import type { MediaSrc } from "../lib/vidstack";
 import {
@@ -12,6 +13,7 @@ import { AudioTrackSelector } from "./audio-track-selector";
 import { MediaSessionSync } from "./media-session-sync";
 import { PlayerDefaults } from "./player-internals";
 import { buildSafeSubtitleTracks } from "./subtitle-track-utils";
+import { Toast } from "./toast";
 import { onProviderChange } from "./video-player-core";
 import { VolumeRestorer } from "./volume-restorer";
 
@@ -55,6 +57,14 @@ export function ShortsVideoPlayer({
   const ios = isIosDevice();
   const srcKey = typeof src === "string" ? src : String(src.src);
   const subtitleTracks = buildSafeSubtitleTracks(subtitles);
+  const shouldPreferOriginalLanguage = preferOriginalLanguage ?? true;
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 2600);
+    return () => clearTimeout(timer);
+  }, [toast]);
 
   return (
     <div style={{ position: "absolute", inset: 0, backgroundColor: "black" }}>
@@ -117,8 +127,12 @@ export function ShortsVideoPlayer({
           }}
         />
         <PlayerDefaults
-          defaultAudioLanguage={defaultAudioLanguage}
-          preferOriginalLanguage={preferOriginalLanguage}
+          defaultAudioLanguage={defaultAudioLanguage || "en"}
+          preferOriginalLanguage={shouldPreferOriginalLanguage}
+          requireOriginalLanguage
+          onOriginalLanguageUnavailable={() => {
+            setToast("Original audio unavailable, switched to English");
+          }}
           originalAudioLocale={originalAudioLocale}
           defaultSubtitleLanguage={defaultSubtitleLanguage}
           subtitlesEnabled={subtitlesEnabled}
@@ -132,6 +146,7 @@ export function ShortsVideoPlayer({
         />
         <MediaSessionSync title={title} artwork={poster} />
       </MediaPlayer>
+      <Toast message={toast} />
     </div>
   );
 }

--- a/apps/web/src/components/subtitle-size-selector.tsx
+++ b/apps/web/src/components/subtitle-size-selector.tsx
@@ -2,6 +2,8 @@ import type { DefaultLayoutIcon } from "../lib/vidstack";
 import { DefaultMenuButton, DefaultMenuRadioGroup, Menu, OdometerIcon } from "../lib/vidstack";
 
 const sizeIcon: DefaultLayoutIcon = (props) => <OdometerIcon {...props} />;
+const MENU_ITEMS_CLASS =
+  "vds-menu-items overflow-y-auto overscroll-y-contain pr-0.5 [scrollbar-width:thin] [scrollbar-color:var(--color-zinc-500)_transparent] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-surface-soft/80 [&::-webkit-scrollbar-thumb:hover]:bg-surface-soft [&::-webkit-scrollbar-track]:bg-transparent";
 
 type FontSize = "small" | "normal" | "large" | "huge";
 
@@ -31,7 +33,7 @@ export function SubtitleSizeSelector({ value, onChange }: Props) {
   return (
     <Menu.Root className="vds-font-size-menu vds-menu">
       <DefaultMenuButton label="Subtitle Size" hint={current.label} Icon={sizeIcon} />
-      <Menu.Items className="vds-menu-items">
+      <Menu.Items className={MENU_ITEMS_CLASS}>
         <DefaultMenuRadioGroup value={value} options={radioOptions} onChange={onSelect} />
       </Menu.Items>
     </Menu.Root>

--- a/apps/web/src/components/watch-layout.tsx
+++ b/apps/web/src/components/watch-layout.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useBulletComments } from "../hooks/use-bullet-comments";
 import { usePlayerError } from "../hooks/use-player-error";
 import { useSaveProgress } from "../hooks/use-progress";
@@ -18,6 +18,7 @@ import { DanmakuOverlay } from "./danmaku-overlay";
 import { PlayerError } from "./player-error";
 import { PlayerDefaults, PlayerFocuser } from "./player-internals";
 import { RelatedVideos } from "./related-videos";
+import { Toast } from "./toast";
 import { VideoPlayer } from "./video-player";
 import { WatchMeta } from "./watch-meta";
 
@@ -45,6 +46,7 @@ export function WatchLayout({ stream, startTime }: Props) {
       ?.audioLocale ?? null;
   const cinemaMode = useWatchLayoutStore((state) => state.cinemaMode);
   const seekRef = useRef<((seconds: number) => void) | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
   const handleVolumeChange = useVolumeSync(update.mutate);
   const { thumbnailVtt, chaptersVtt } = useWatchVttAssets(stream);
   const { positionRef, handleTimeUpdate, handlePause, handleSeeked } = useWatchProgressPersistence({
@@ -54,6 +56,12 @@ export function WatchLayout({ stream, startTime }: Props) {
   });
 
   useWatchRecommendationTracking(stream, isLive, positionRef);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 2600);
+    return () => clearTimeout(timer);
+  }, [toast]);
 
   const handleEnded = useCallback(() => {
     if (!settingsReady || !settings.autoplay) return;
@@ -70,8 +78,12 @@ export function WatchLayout({ stream, startTime }: Props) {
       <PlayerFocuser />
       <PlayerDefaults
         defaultQuality={qualityFailed ? undefined : settings.defaultQuality}
-        defaultAudioLanguage={settings.defaultAudioLanguage || undefined}
+        defaultAudioLanguage={settings.defaultAudioLanguage || "en"}
         preferOriginalLanguage={settings.preferOriginalLanguage}
+        requireOriginalLanguage
+        onOriginalLanguageUnavailable={() => {
+          setToast("Original audio unavailable, switched to English");
+        }}
         originalAudioLocale={originalLocale}
         subtitlesEnabled={settings.subtitlesEnabled}
         defaultSubtitleLanguage={settings.defaultSubtitleLanguage || undefined}
@@ -107,7 +119,7 @@ export function WatchLayout({ stream, startTime }: Props) {
             initialVolume={settings.volume}
             initialMuted={settings.muted}
             settingsReady={settingsReady}
-            autoplay={settingsReady && settings.autoplay}
+            autoplay={settingsReady}
             originalAudioLocale={originalLocale}
             overlay={overlay}
             onVolumeChange={handleVolumeChange}
@@ -141,6 +153,7 @@ export function WatchLayout({ stream, startTime }: Props) {
           </div>
         </div>
       )}
+      <Toast message={toast} />
     </div>
   );
 }

--- a/apps/web/src/hooks/use-settings.ts
+++ b/apps/web/src/hooks/use-settings.ts
@@ -15,8 +15,8 @@ const DEFAULTS: SettingsItem = {
   muted: false,
   subtitlesEnabled: false,
   defaultSubtitleLanguage: "",
-  defaultAudioLanguage: "",
-  preferOriginalLanguage: false,
+  defaultAudioLanguage: "en",
+  preferOriginalLanguage: true,
   recommendationPersonalizationEnabled: true,
 };
 

--- a/apps/web/src/routes/shorts.tsx
+++ b/apps/web/src/routes/shorts.tsx
@@ -22,11 +22,11 @@ function ShortsBetaBanner() {
 
   return (
     <div
-      className="pointer-events-none fixed left-2 right-2 z-40 flex justify-center sm:left-4 sm:right-4"
+      className="pointer-events-none fixed right-2 z-40 sm:right-4"
       style={{ top: "calc(3.5rem + env(safe-area-inset-top, 0px) + 0.5rem)" }}
     >
-      <div className="pointer-events-auto flex w-full max-w-3xl items-center gap-3 rounded-xl border border-border-strong bg-app/95 px-3 py-2 backdrop-blur sm:px-4">
-        <p className="text-xs text-fg-muted sm:text-sm">
+      <div className="pointer-events-auto flex w-[min(22rem,calc(100vw-1rem))] items-center gap-2 rounded-lg border border-border-strong bg-app/95 px-3 py-2 shadow-lg backdrop-blur sm:w-[min(24rem,calc(100vw-2rem))]">
+        <p className="text-[11px] leading-4 text-fg-muted sm:text-xs">
           The shorts page is still beta and some bugs can happen.
         </p>
         <button


### PR DESCRIPTION
## Summary
- enforce original-audio-first selection in watch and shorts players, add English fallback, and show a toast when the original track is unavailable
- apply Tailwind-style scrollbar treatment to Vidstack menu lists (audio, quality, format, subtitle size) and keep the shorts beta banner compact/non-intrusive
- set playback defaults to `defaultAudioLanguage: \"en\"` and `preferOriginalLanguage: true`, while keeping direct playback start behavior unchanged

## Validation
- bun run check
- bun run build