### PR TITLE
fix: apply backend deterministic audio track contract

### DIFF
--- a/apps/web/src/components/audio-track-selector.tsx
+++ b/apps/web/src/components/audio-track-selector.tsx
@@ -7,6 +7,7 @@ import {
   Menu,
   useAudioOptions,
 } from "../lib/vidstack";
+import { includesOriginal, normalizeLanguageTag } from "./player-language";
 
 const languageIcon: DefaultLayoutIcon = (props) => <LanguageIcon {...props} />;
 const MENU_ITEMS_CLASS =
@@ -23,14 +24,20 @@ export function AudioTrackSelector({ originalLocale }: Props) {
   if (options.length <= 1) return null;
 
   const selectedOption = options.find((o) => o.selected) ?? options[0];
-  const selectedIsOriginal =
-    originalLocale != null && selectedOption?.track.language === originalLocale;
+  const selectedTrackLooksOriginal = includesOriginal(selectedOption?.label);
+  const selectedMatchesOriginalLocale =
+    originalLocale != null &&
+    normalizeLanguageTag(selectedOption?.track.language) === normalizeLanguageTag(originalLocale);
+  const selectedIsOriginal = selectedTrackLooksOriginal || selectedMatchesOriginalLocale;
   const currentHint = selectedIsOriginal
     ? `${selectedOption?.label} (original)`
     : selectedOption?.label;
 
   const radioOptions = options.map((o, index) => {
-    const isOriginal = originalLocale != null && o.track.language === originalLocale;
+    const isOriginal =
+      includesOriginal(o.label) ||
+      (originalLocale != null &&
+        normalizeLanguageTag(o.track.language) === normalizeLanguageTag(originalLocale));
     return {
       label: isOriginal ? `${o.label} (original)` : o.label,
       value: `${o.label}-${o.track.language ?? "und"}-${index}`,

--- a/apps/web/src/components/player-defaults.tsx
+++ b/apps/web/src/components/player-defaults.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from "react";
+import { useAudioOptions, useMediaState, useVideoQualityOptions } from "../lib/vidstack";
+import { includesOriginal, normalizeLanguageTag } from "./player-language";
+
+type PlayerDefaultsProps = {
+  defaultQuality?: string;
+  defaultAudioLanguage?: string;
+  preferOriginalLanguage?: boolean;
+  requireOriginalLanguage?: boolean;
+  onOriginalLanguageUnavailable?: () => void;
+  originalAudioTrackId?: string | null;
+  preferredDefaultAudioTrackId?: string | null;
+  originalAudioLocale?: string | null;
+  subtitlesEnabled?: boolean;
+  defaultSubtitleLanguage?: string;
+};
+
+export function PlayerDefaults({
+  defaultQuality,
+  defaultAudioLanguage,
+  preferOriginalLanguage,
+  requireOriginalLanguage,
+  onOriginalLanguageUnavailable,
+  originalAudioTrackId,
+  preferredDefaultAudioTrackId,
+  originalAudioLocale,
+  subtitlesEnabled,
+  defaultSubtitleLanguage,
+}: PlayerDefaultsProps) {
+  const canPlay = useMediaState("canPlay");
+  const qualityOptions = useVideoQualityOptions({ sort: "descending" });
+  const audioOptions = useAudioOptions();
+  const textTracks = useMediaState("textTracks");
+  const qualityApplied = useRef(false);
+  const appliedAudioOptionsCount = useRef(0);
+  const subtitleApplied = useRef(false);
+  const originalMissingNotified = useRef(false);
+
+  const preferredTag = normalizeLanguageTag(defaultAudioLanguage);
+  const originalTag = normalizeLanguageTag(originalAudioLocale);
+
+  useEffect(() => {
+    if (!canPlay || qualityApplied.current || !defaultQuality) return;
+    const match = qualityOptions.find((o) => o.label === defaultQuality);
+    if (!match) return;
+    match.select();
+    qualityApplied.current = true;
+  }, [canPlay, qualityOptions, defaultQuality]);
+
+  useEffect(() => {
+    const forceOriginal = requireOriginalLanguage || preferOriginalLanguage;
+    const canReapplyOriginalSelection =
+      forceOriginal &&
+      appliedAudioOptionsCount.current > 0 &&
+      audioOptions.length > appliedAudioOptionsCount.current;
+    const selectedTrackId = audioOptions.find((option) => option.selected)?.track.id;
+    const expectedTrackId = forceOriginal
+      ? (originalAudioTrackId ?? preferredDefaultAudioTrackId ?? undefined)
+      : (preferredDefaultAudioTrackId ?? undefined);
+    const shouldFixMismatchedSelection =
+      expectedTrackId !== undefined &&
+      expectedTrackId !== null &&
+      selectedTrackId !== undefined &&
+      selectedTrackId !== expectedTrackId;
+    if (
+      audioOptions.length === 0 ||
+      (appliedAudioOptionsCount.current > 0 &&
+        !canReapplyOriginalSelection &&
+        !shouldFixMismatchedSelection)
+    ) {
+      return;
+    }
+
+    let match = forceOriginal
+      ? (audioOptions.find((option) => option.track.id === originalAudioTrackId) ??
+        audioOptions.find((option) => option.track.id === preferredDefaultAudioTrackId) ??
+        audioOptions.find((option) => includesOriginal(option.label)) ??
+        audioOptions.find((option) => normalizeLanguageTag(option.track.language) === originalTag))
+      : (audioOptions.find((option) => option.track.id === preferredDefaultAudioTrackId) ??
+        audioOptions.find((option) => option.track.id === originalAudioTrackId));
+
+    const missingOriginalByContract = forceOriginal && originalAudioTrackId === null;
+    const missingOriginalByHeuristic =
+      forceOriginal && originalAudioTrackId === undefined && !match;
+    if (
+      (missingOriginalByContract || missingOriginalByHeuristic) &&
+      !originalMissingNotified.current
+    ) {
+      originalMissingNotified.current = true;
+      onOriginalLanguageUnavailable?.();
+    }
+
+    if (!match) {
+      match = audioOptions.find(
+        (option) => normalizeLanguageTag(option.track.language) === preferredTag,
+      );
+    }
+    if (!match) {
+      match = audioOptions[0];
+    }
+    if (!match || selectedTrackId === match.track.id) return;
+
+    match.select();
+    appliedAudioOptionsCount.current = audioOptions.length;
+  }, [
+    audioOptions,
+    originalAudioTrackId,
+    preferredDefaultAudioTrackId,
+    preferOriginalLanguage,
+    requireOriginalLanguage,
+    originalTag,
+    preferredTag,
+    onOriginalLanguageUnavailable,
+  ]);
+
+  useEffect(() => {
+    if (!canPlay || subtitleApplied.current || !subtitlesEnabled) return;
+    for (const track of textTracks) {
+      if (track.kind !== "subtitles" && track.kind !== "captions") continue;
+      if (defaultSubtitleLanguage && track.language !== defaultSubtitleLanguage) continue;
+      track.setMode("showing");
+      subtitleApplied.current = true;
+      break;
+    }
+  }, [canPlay, textTracks, subtitlesEnabled, defaultSubtitleLanguage]);
+
+  return null;
+}

--- a/apps/web/src/components/player-internals.tsx
+++ b/apps/web/src/components/player-internals.tsx
@@ -1,14 +1,7 @@
 import { useEffect, useRef } from "react";
 import { isIosDevice } from "../lib/ios-device";
-import {
-  useAudioOptions,
-  useMediaPlayer,
-  useMediaRemote,
-  useMediaState,
-  useVideoQualityOptions,
-} from "../lib/vidstack";
+import { useMediaPlayer, useMediaRemote, useMediaState } from "../lib/vidstack";
 import type { SponsorBlockSegmentItem } from "../types/api";
-import { includesOriginal, normalizeLanguageTag } from "./player-language";
 
 export function SeekBridge({
   onSeekReady,
@@ -65,106 +58,5 @@ export function SponsorBlockSkipper({ segments }: { segments: SponsorBlockSegmen
       }
     }
   }, [currentTime, segments, remote]);
-  return null;
-}
-
-type PlayerDefaultsProps = {
-  defaultQuality?: string;
-  defaultAudioLanguage?: string;
-  preferOriginalLanguage?: boolean;
-  requireOriginalLanguage?: boolean;
-  onOriginalLanguageUnavailable?: () => void;
-  originalAudioLocale?: string | null;
-  subtitlesEnabled?: boolean;
-  defaultSubtitleLanguage?: string;
-};
-
-export function PlayerDefaults({
-  defaultQuality,
-  defaultAudioLanguage,
-  preferOriginalLanguage,
-  requireOriginalLanguage,
-  onOriginalLanguageUnavailable,
-  originalAudioLocale,
-  subtitlesEnabled,
-  defaultSubtitleLanguage,
-}: PlayerDefaultsProps) {
-  const canPlay = useMediaState("canPlay");
-  const qualityOptions = useVideoQualityOptions({ sort: "descending" });
-  const audioOptions = useAudioOptions();
-  const textTracks = useMediaState("textTracks");
-  const qualityApplied = useRef(false);
-  const appliedAudioOptionsCount = useRef(0);
-  const subtitleApplied = useRef(false);
-  const originalMissingNotified = useRef(false);
-
-  const preferredTag = normalizeLanguageTag(defaultAudioLanguage);
-  const originalTag = normalizeLanguageTag(originalAudioLocale);
-
-  useEffect(() => {
-    if (!canPlay || qualityApplied.current || !defaultQuality) return;
-    const match = qualityOptions.find((o) => o.label === defaultQuality);
-    if (match) {
-      match.select();
-      qualityApplied.current = true;
-    }
-  }, [canPlay, qualityOptions, defaultQuality]);
-
-  useEffect(() => {
-    const forceOriginal = requireOriginalLanguage || preferOriginalLanguage;
-    const canReapplyOriginalSelection =
-      forceOriginal &&
-      appliedAudioOptionsCount.current > 0 &&
-      audioOptions.length > appliedAudioOptionsCount.current;
-    if (
-      !canPlay ||
-      audioOptions.length === 0 ||
-      (appliedAudioOptionsCount.current > 0 && !canReapplyOriginalSelection)
-    ) {
-      return;
-    }
-    let match = forceOriginal
-      ? (audioOptions.find((option) => includesOriginal(option.label)) ??
-        audioOptions.find((option) => normalizeLanguageTag(option.track.language) === originalTag))
-      : undefined;
-    if (!match && forceOriginal && !originalMissingNotified.current) {
-      originalMissingNotified.current = true;
-      onOriginalLanguageUnavailable?.();
-    }
-    if (!match) {
-      match = audioOptions.find(
-        (option) => normalizeLanguageTag(option.track.language) === preferredTag,
-      );
-    }
-    if (!match) {
-      match = audioOptions[0];
-    }
-    if (match) {
-      match.select();
-      appliedAudioOptionsCount.current = audioOptions.length;
-    }
-  }, [
-    canPlay,
-    audioOptions,
-    preferOriginalLanguage,
-    requireOriginalLanguage,
-    originalTag,
-    preferredTag,
-    onOriginalLanguageUnavailable,
-  ]);
-
-  useEffect(() => {
-    if (!canPlay || subtitleApplied.current || !subtitlesEnabled) return;
-    const count = textTracks.length;
-    for (let i = 0; i < count; i++) {
-      const track = textTracks[i];
-      if (track.kind !== "subtitles" && track.kind !== "captions") continue;
-      if (defaultSubtitleLanguage && track.language !== defaultSubtitleLanguage) continue;
-      track.setMode("showing");
-      subtitleApplied.current = true;
-      break;
-    }
-  }, [canPlay, textTracks, subtitlesEnabled, defaultSubtitleLanguage]);
-
   return null;
 }

--- a/apps/web/src/components/shorts-comments-sheet-slot.tsx
+++ b/apps/web/src/components/shorts-comments-sheet-slot.tsx
@@ -1,0 +1,22 @@
+import { lazy, Suspense } from "react";
+
+const ShortsCommentsSheet = lazy(() =>
+  import("../components/shorts-comments-sheet").then((module) => ({
+    default: module.ShortsCommentsSheet,
+  })),
+);
+
+type Props = {
+  videoUrl: string;
+  anchorEl: HTMLDivElement | null;
+  open: boolean;
+  onClose: () => void;
+};
+
+export function ShortsCommentsSheetSlot({ videoUrl, anchorEl, open, onClose }: Props) {
+  return (
+    <Suspense fallback={null}>
+      <ShortsCommentsSheet videoUrl={videoUrl} anchorEl={anchorEl} open={open} onClose={onClose} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/shorts-player-shell.tsx
+++ b/apps/web/src/components/shorts-player-shell.tsx
@@ -8,18 +8,16 @@ import { useShortsFeed } from "../hooks/use-shorts-feed";
 import { useShortsPrefetch } from "../hooks/use-shorts-prefetch";
 import { useShortsRouteSync } from "../hooks/use-shorts-route-sync";
 import { useVolumeSync } from "../hooks/use-volume-sync";
+import {
+  getOriginalAudioLocale,
+  getOriginalAudioTrackId,
+  getPreferredDefaultAudioTrackId,
+} from "../lib/audio-track";
 import { trackRecommendationEvent } from "../lib/recommendation-tracker";
 import { useShortsNavigation } from "../lib/shorts-navigation";
 import { trackShortsAutoAdvance, trackShortsUserMove } from "../lib/shorts-tracking";
 import { useUiStore } from "../stores/ui-store";
 import type { VideoStream } from "../types/stream";
-
-function findOriginalAudioLocale(stream: VideoStream | undefined): string | null {
-  return (
-    stream?.audioStreams?.find((track) => track.audioTrackName?.toLowerCase().includes("original"))
-      ?.audioLocale ?? null
-  );
-}
 
 type Props = {
   targetUrl?: string;
@@ -76,7 +74,9 @@ export function ShortsPlayerShell({ targetUrl }: Props) {
       intent: shortsIntent,
     });
   }, [active, settings.defaultService, shortsIntent]);
-  const originalAudioLocale = findOriginalAudioLocale(stream);
+  const originalAudioTrackId = getOriginalAudioTrackId(stream);
+  const preferredDefaultAudioTrackId = getPreferredDefaultAudioTrackId(stream);
+  const originalAudioLocale = getOriginalAudioLocale(stream);
   const onVolumeChange = useVolumeSync(update.mutate);
   useShortsPrefetch(
     shorts.map((item) => item.id),
@@ -143,6 +143,8 @@ export function ShortsPlayerShell({ targetUrl }: Props) {
       initialMuted={settings.muted}
       defaultAudioLanguage={settings.defaultAudioLanguage || undefined}
       preferOriginalLanguage={settings.preferOriginalLanguage}
+      originalAudioTrackId={originalAudioTrackId}
+      preferredDefaultAudioTrackId={preferredDefaultAudioTrackId}
       originalAudioLocale={originalAudioLocale}
       defaultSubtitleLanguage={settings.defaultSubtitleLanguage || undefined}
       subtitlesEnabled={settings.subtitlesEnabled}

--- a/apps/web/src/components/shorts-player-stage.tsx
+++ b/apps/web/src/components/shorts-player-stage.tsx
@@ -1,6 +1,6 @@
-import { lazy, Suspense } from "react";
 import { PageSpinner } from "../components/page-spinner";
 import { ShortsActions } from "../components/shorts-actions";
+import { ShortsCommentsSheetSlot } from "../components/shorts-comments-sheet-slot";
 import { ShortsError } from "../components/shorts-error";
 import { ShortsInfoOverlay } from "../components/shorts-info-overlay";
 import { ShortsNavigation } from "../components/shorts-navigation";
@@ -8,11 +8,6 @@ import { ShortsVideoPlayer } from "../components/shorts-video-player";
 import { resolveManifestSrc } from "../lib/stream-src";
 import type { VideoStream } from "../types/stream";
 
-const ShortsCommentsSheet = lazy(() =>
-  import("../components/shorts-comments-sheet").then((module) => ({
-    default: module.ShortsCommentsSheet,
-  })),
-);
 type Props = {
   sectionClass: string;
   playerRef: React.RefObject<HTMLDivElement | null>;
@@ -32,6 +27,8 @@ type Props = {
   initialMuted: boolean;
   defaultAudioLanguage?: string;
   preferOriginalLanguage?: boolean;
+  originalAudioTrackId?: string | null;
+  preferredDefaultAudioTrackId?: string | null;
   originalAudioLocale?: string | null;
   defaultSubtitleLanguage?: string;
   subtitlesEnabled?: boolean;
@@ -46,7 +43,6 @@ type Props = {
   onTouchEnd: (clientY: number | null, target: EventTarget | null) => void;
   onVolumeChange: (volume: number, muted: boolean) => void;
 };
-
 export function ShortsPlayerStage({
   sectionClass,
   playerRef,
@@ -66,6 +62,8 @@ export function ShortsPlayerStage({
   initialMuted,
   defaultAudioLanguage,
   preferOriginalLanguage,
+  originalAudioTrackId,
+  preferredDefaultAudioTrackId,
   originalAudioLocale,
   defaultSubtitleLanguage,
   subtitlesEnabled,
@@ -134,6 +132,8 @@ export function ShortsPlayerStage({
                 autoplay={shouldAutoplay}
                 defaultAudioLanguage={defaultAudioLanguage}
                 preferOriginalLanguage={preferOriginalLanguage}
+                originalAudioTrackId={originalAudioTrackId}
+                preferredDefaultAudioTrackId={preferredDefaultAudioTrackId}
                 originalAudioLocale={originalAudioLocale}
                 defaultSubtitleLanguage={defaultSubtitleLanguage}
                 subtitlesEnabled={subtitlesEnabled}
@@ -158,14 +158,12 @@ export function ShortsPlayerStage({
           </div>
         </div>
       </div>
-      <Suspense fallback={null}>
-        <ShortsCommentsSheet
-          videoUrl={active.id}
-          anchorEl={playerRef.current}
-          open={commentsOpen}
-          onClose={onCloseComments}
-        />
-      </Suspense>
+      <ShortsCommentsSheetSlot
+        videoUrl={active.id}
+        anchorEl={playerRef.current}
+        open={commentsOpen}
+        onClose={onCloseComments}
+      />
     </section>
   );
 }

--- a/apps/web/src/components/shorts-video-player.tsx
+++ b/apps/web/src/components/shorts-video-player.tsx
@@ -11,7 +11,7 @@ import {
 import type { SubtitleItem } from "../types/api";
 import { AudioTrackSelector } from "./audio-track-selector";
 import { MediaSessionSync } from "./media-session-sync";
-import { PlayerDefaults } from "./player-internals";
+import { PlayerDefaults } from "./player-defaults";
 import { buildSafeSubtitleTracks } from "./subtitle-track-utils";
 import { Toast } from "./toast";
 import { onProviderChange } from "./video-player-core";
@@ -28,6 +28,8 @@ type Props = {
   autoplay?: boolean;
   defaultAudioLanguage?: string;
   preferOriginalLanguage?: boolean;
+  originalAudioTrackId?: string | null;
+  preferredDefaultAudioTrackId?: string | null;
   originalAudioLocale?: string | null;
   defaultSubtitleLanguage?: string;
   subtitlesEnabled?: boolean;
@@ -47,6 +49,8 @@ export function ShortsVideoPlayer({
   autoplay = true,
   defaultAudioLanguage,
   preferOriginalLanguage,
+  originalAudioTrackId,
+  preferredDefaultAudioTrackId,
   originalAudioLocale,
   defaultSubtitleLanguage,
   subtitlesEnabled,
@@ -133,6 +137,8 @@ export function ShortsVideoPlayer({
           onOriginalLanguageUnavailable={() => {
             setToast("Original audio unavailable, switched to English");
           }}
+          originalAudioTrackId={originalAudioTrackId}
+          preferredDefaultAudioTrackId={preferredDefaultAudioTrackId}
           originalAudioLocale={originalAudioLocale}
           defaultSubtitleLanguage={defaultSubtitleLanguage}
           subtitlesEnabled={subtitlesEnabled}

--- a/apps/web/src/components/watch-layout.tsx
+++ b/apps/web/src/components/watch-layout.tsx
@@ -10,13 +10,19 @@ import {
   useWatchVttAssets,
 } from "../hooks/use-watch-layout-assets";
 import { useWatchProgressPersistence } from "../hooks/use-watch-progress-persistence";
+import {
+  getOriginalAudioLocale,
+  getOriginalAudioTrackId,
+  getPreferredDefaultAudioTrackId,
+} from "../lib/audio-track";
 import { detectProvider } from "../lib/provider";
 import { useDanmakuStore } from "../stores/danmaku-store";
 import { useWatchLayoutStore } from "../stores/watch-layout-store";
 import type { VideoStream } from "../types/stream";
 import { DanmakuOverlay } from "./danmaku-overlay";
+import { PlayerDefaults } from "./player-defaults";
 import { PlayerError } from "./player-error";
-import { PlayerDefaults, PlayerFocuser } from "./player-internals";
+import { PlayerFocuser } from "./player-internals";
 import { RelatedVideos } from "./related-videos";
 import { Toast } from "./toast";
 import { VideoPlayer } from "./video-player";
@@ -41,9 +47,9 @@ export function WatchLayout({ stream, startTime }: Props) {
   const { on: bulletCommentsOn } = useDanmakuStore();
   const isNicoNico = detectProvider(stream.id) === "nicovideo";
   const { data: bulletComments } = useBulletComments(stream.id, isNicoNico);
-  const originalLocale =
-    stream.audioStreams?.find((a) => a.audioTrackName?.toLowerCase().includes("original"))
-      ?.audioLocale ?? null;
+  const originalTrackId = getOriginalAudioTrackId(stream);
+  const preferredAudioTrackId = getPreferredDefaultAudioTrackId(stream);
+  const originalLocale = getOriginalAudioLocale(stream);
   const cinemaMode = useWatchLayoutStore((state) => state.cinemaMode);
   const seekRef = useRef<((seconds: number) => void) | null>(null);
   const [toast, setToast] = useState<string | null>(null);
@@ -84,6 +90,8 @@ export function WatchLayout({ stream, startTime }: Props) {
         onOriginalLanguageUnavailable={() => {
           setToast("Original audio unavailable, switched to English");
         }}
+        originalAudioTrackId={originalTrackId}
+        preferredDefaultAudioTrackId={preferredAudioTrackId}
         originalAudioLocale={originalLocale}
         subtitlesEnabled={settings.subtitlesEnabled}
         defaultSubtitleLanguage={settings.defaultSubtitleLanguage || undefined}

--- a/apps/web/src/lib/audio-track.ts
+++ b/apps/web/src/lib/audio-track.ts
@@ -1,0 +1,43 @@
+import type { AudioStreamItem } from "../types/api";
+import type { VideoStream } from "../types/stream";
+
+function includesOriginal(value: string | undefined): boolean {
+  if (!value) return false;
+  return value.toLowerCase().includes("original");
+}
+
+function findTrackById(
+  audioStreams: AudioStreamItem[] | undefined,
+  trackId: string | null | undefined,
+): AudioStreamItem | undefined {
+  if (!audioStreams || !trackId) return undefined;
+  return audioStreams.find((track) => track.audioTrackId === trackId);
+}
+
+export function getOriginalAudioTrackId(stream: VideoStream | undefined): string | null {
+  if (!stream) return null;
+  if (stream.originalAudioTrackId) return stream.originalAudioTrackId;
+  return (
+    stream.audioStreams?.find((track) => track.isOriginal && track.audioTrackId)?.audioTrackId ??
+    stream.audioStreams?.find((track) => includesOriginal(track.audioTrackName ?? undefined))
+      ?.audioTrackId ??
+    null
+  );
+}
+
+export function getPreferredDefaultAudioTrackId(stream: VideoStream | undefined): string | null {
+  if (!stream) return null;
+  return stream.preferredDefaultAudioTrackId ?? getOriginalAudioTrackId(stream);
+}
+
+export function getOriginalAudioLocale(stream: VideoStream | undefined): string | null {
+  if (!stream) return null;
+  const byOriginalId = findTrackById(stream.audioStreams, getOriginalAudioTrackId(stream));
+  if (byOriginalId?.audioLocale) return byOriginalId.audioLocale;
+  return (
+    stream.audioStreams?.find((track) => track.isOriginal)?.audioLocale ??
+    stream.audioStreams?.find((track) => includesOriginal(track.audioTrackName ?? undefined))
+      ?.audioLocale ??
+    null
+  );
+}

--- a/apps/web/src/lib/mappers.ts
+++ b/apps/web/src/lib/mappers.ts
@@ -96,6 +96,8 @@ export function mapStreamResponse(response: StreamResponse, url: string): VideoS
     hlsUrl: response.hlsUrl || undefined,
     videoOnlyStreams: response.videoOnlyStreams,
     audioStreams: response.audioStreams,
+    originalAudioTrackId: response.originalAudioTrackId,
+    preferredDefaultAudioTrackId: response.preferredDefaultAudioTrackId,
     subtitles: response.subtitles.length > 0 ? response.subtitles : undefined,
     previewFrames: response.previewFrames.length > 0 ? response.previewFrames : undefined,
     sponsorBlockSegments:

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -63,6 +63,8 @@ export type StreamResponse = {
   streamSegments: StreamSegmentItem[];
   hlsUrl: string;
   dashMpdUrl: string;
+  originalAudioTrackId: string | null;
+  preferredDefaultAudioTrackId: string | null;
   videoStreams: VideoStreamItem[];
   audioStreams: AudioStreamItem[];
   videoOnlyStreams: VideoStreamItem[];

--- a/apps/web/src/types/stream-items.ts
+++ b/apps/web/src/types/stream-items.ts
@@ -27,6 +27,7 @@ export type AudioStreamItem = {
   audioTrackId: string | null;
   audioTrackName: string | null;
   audioLocale: string | null;
+  isOriginal: boolean;
   itag: number;
   contentLength: number;
   initStart: number;

--- a/apps/web/src/types/stream.ts
+++ b/apps/web/src/types/stream.ts
@@ -36,6 +36,8 @@ export type VideoStream = {
   related?: VideoStream[];
   videoOnlyStreams?: VideoStreamItem[];
   audioStreams?: AudioStreamItem[];
+  originalAudioTrackId?: string | null;
+  preferredDefaultAudioTrackId?: string | null;
   subtitles?: SubtitleItem[];
   previewFrames?: PreviewFrameItem[];
   sponsorBlockSegments?: SponsorBlockSegmentItem[];


### PR DESCRIPTION
## Summary
- consume backend session-198 audio contract in `/streams` (`audioStreams[].isOriginal`, `originalAudioTrackId`, `preferredDefaultAudioTrackId`) and map it into frontend stream types
- make watch/shorts player defaults choose audio deterministically by backend track id, with guarded fallback behavior and mismatch re-selection for mobile startup races
- harden language menu original labeling and split player defaults/comments sheet helpers to keep files under the 170-line limit

## Validation
- bun run check
- bun run build