### PR TITLE
fix: add playback compatibility mode for iOS legacy

### DIFF
--- a/apps/web/src/hooks/use-playback-mode.ts
+++ b/apps/web/src/hooks/use-playback-mode.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from "react";
+import {
+  type PlaybackMode,
+  readPlaybackMode,
+  setPlaybackMode,
+  subscribePlaybackMode,
+} from "../lib/playback-mode";
+
+export function usePlaybackMode(): {
+  playbackMode: PlaybackMode;
+  setMode: (next: PlaybackMode) => void;
+} {
+  const playbackMode = useSyncExternalStore<PlaybackMode>(
+    subscribePlaybackMode,
+    readPlaybackMode,
+    readPlaybackMode,
+  );
+
+  return {
+    playbackMode,
+    setMode: setPlaybackMode,
+  };
+}

--- a/apps/web/src/lib/mappers.ts
+++ b/apps/web/src/lib/mappers.ts
@@ -94,6 +94,7 @@ export function mapStreamResponse(response: StreamResponse, url: string): VideoS
     startPosition: response.startPosition > 0 ? response.startPosition : undefined,
     streamSegments: response.streamSegments.length > 0 ? response.streamSegments : undefined,
     hlsUrl: response.hlsUrl || undefined,
+    videoStreams: response.videoStreams,
     videoOnlyStreams: response.videoOnlyStreams,
     audioStreams: response.audioStreams,
     originalAudioTrackId: response.originalAudioTrackId,

--- a/apps/web/src/lib/playback-mode.ts
+++ b/apps/web/src/lib/playback-mode.ts
@@ -1,0 +1,50 @@
+export type PlaybackMode = "adaptive" | "ios-legacy-compat";
+
+const STORAGE_KEY = "typed-playback-mode";
+const CHANGE_EVENT = "typed:playback-mode-change";
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function isPlaybackMode(value: string | null): value is PlaybackMode {
+  return value === "adaptive" || value === "ios-legacy-compat";
+}
+
+export function readPlaybackMode(): PlaybackMode {
+  if (!canUseStorage()) return "adaptive";
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return isPlaybackMode(stored) ? stored : "adaptive";
+}
+
+export function writePlaybackMode(mode: PlaybackMode): void {
+  if (!canUseStorage()) return;
+  window.localStorage.setItem(STORAGE_KEY, mode);
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function setPlaybackMode(mode: PlaybackMode): void {
+  writePlaybackMode(mode);
+}
+
+export function subscribePlaybackMode(listener: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key !== STORAGE_KEY) return;
+    listener();
+  };
+  const onChange = () => listener();
+
+  window.addEventListener("storage", onStorage);
+  window.addEventListener(CHANGE_EVENT, onChange);
+
+  return () => {
+    window.removeEventListener("storage", onStorage);
+    window.removeEventListener(CHANGE_EVENT, onChange);
+  };
+}
+
+export function isCompatibilityPlaybackMode(): boolean {
+  return readPlaybackMode() === "ios-legacy-compat";
+}

--- a/apps/web/src/lib/playback-mode.ts
+++ b/apps/web/src/lib/playback-mode.ts
@@ -17,14 +17,10 @@ export function readPlaybackMode(): PlaybackMode {
   return isPlaybackMode(stored) ? stored : "adaptive";
 }
 
-export function writePlaybackMode(mode: PlaybackMode): void {
+export function setPlaybackMode(mode: PlaybackMode): void {
   if (!canUseStorage()) return;
   window.localStorage.setItem(STORAGE_KEY, mode);
   window.dispatchEvent(new Event(CHANGE_EVENT));
-}
-
-export function setPlaybackMode(mode: PlaybackMode): void {
-  writePlaybackMode(mode);
 }
 
 export function subscribePlaybackMode(listener: () => void): () => void {

--- a/apps/web/src/lib/stream-audio-compact.ts
+++ b/apps/web/src/lib/stream-audio-compact.ts
@@ -1,0 +1,42 @@
+import type { AudioStreamItem } from "../types/api";
+
+function normalizeLanguageTag(value: string | null): string {
+  if (value === null || value.length === 0) return "";
+  const [base] = value.toLowerCase().split("-");
+  return base ?? "";
+}
+
+function isOriginalTrack(track: AudioStreamItem): boolean {
+  if (track.isOriginal) return true;
+  return track.audioTrackName?.toLowerCase().includes("original") ?? false;
+}
+
+export function pickCompactAudioTracks(
+  audioStreams: AudioStreamItem[],
+  preferredAudioLanguage: string | undefined,
+  maxCompactAudioTracks: number,
+): AudioStreamItem[] {
+  if (audioStreams.length <= maxCompactAudioTracks) return audioStreams;
+  const preferredTag = normalizeLanguageTag(preferredAudioLanguage ?? null);
+  const prioritized = [...audioStreams].sort((left, right) => {
+    const leftOriginal = isOriginalTrack(left);
+    const rightOriginal = isOriginalTrack(right);
+    if (leftOriginal !== rightOriginal) return leftOriginal ? -1 : 1;
+    const leftPreferred = normalizeLanguageTag(left.audioLocale) === preferredTag;
+    const rightPreferred = normalizeLanguageTag(right.audioLocale) === preferredTag;
+    if (leftPreferred !== rightPreferred) return leftPreferred ? -1 : 1;
+    return (right.bitrate ?? 0) - (left.bitrate ?? 0);
+  });
+
+  const selected: AudioStreamItem[] = [];
+  const seenLanguages = new Set<string>();
+  for (const track of prioritized) {
+    const language = normalizeLanguageTag(track.audioLocale) || `und-${track.itag}`;
+    if (seenLanguages.has(language)) continue;
+    selected.push(track);
+    seenLanguages.add(language);
+    if (selected.length >= maxCompactAudioTracks) break;
+  }
+
+  return selected.length > 0 ? selected : prioritized.slice(0, maxCompactAudioTracks);
+}

--- a/apps/web/src/lib/stream-src.ts
+++ b/apps/web/src/lib/stream-src.ts
@@ -1,10 +1,11 @@
-import type { AudioStreamItem } from "../types/api";
 import type { VideoStream } from "../types/stream";
 import { buildDashManifest } from "./dash-manifest";
 import { API_BASE as BASE } from "./env";
 import { buildNicoMasterPlaylist } from "./nico-manifest";
+import { isCompatibilityPlaybackMode } from "./playback-mode";
 import { detectProvider } from "./provider";
 import { proxyDashManifest } from "./proxy";
+import { pickCompactAudioTracks } from "./stream-audio-compact";
 import type { MediaSrc } from "./vidstack";
 
 type ResolveManifestOptions = {
@@ -13,47 +14,12 @@ type ResolveManifestOptions = {
   preferredAudioLanguage?: string;
   preferOriginalLanguage?: boolean;
   maxCompactAudioTracks?: number;
+  compatibilityMode?: boolean;
 };
 
 function isFirefoxBrowser(): boolean {
   if (typeof navigator === "undefined") return false;
   return navigator.userAgent.includes("Firefox/");
-}
-
-function normalizeLanguageTag(value: string | null): string {
-  if (value === null || value.length === 0) return "";
-  const [base] = value.toLowerCase().split("-");
-  return base ?? "";
-}
-
-function pickCompactAudioTracks(
-  audioStreams: AudioStreamItem[],
-  preferredAudioLanguage: string | undefined,
-  maxCompactAudioTracks: number,
-): AudioStreamItem[] {
-  if (audioStreams.length <= maxCompactAudioTracks) return audioStreams;
-  const preferredTag = normalizeLanguageTag(preferredAudioLanguage ?? null);
-  const prioritized = [...audioStreams].sort((left, right) => {
-    const leftOriginal = left.audioTrackName?.toLowerCase().includes("original") ?? false;
-    const rightOriginal = right.audioTrackName?.toLowerCase().includes("original") ?? false;
-    if (leftOriginal !== rightOriginal) return leftOriginal ? -1 : 1;
-    const leftPreferred = normalizeLanguageTag(left.audioLocale) === preferredTag;
-    const rightPreferred = normalizeLanguageTag(right.audioLocale) === preferredTag;
-    if (leftPreferred !== rightPreferred) return leftPreferred ? -1 : 1;
-    return (right.bitrate ?? 0) - (left.bitrate ?? 0);
-  });
-
-  const selected: AudioStreamItem[] = [];
-  const seenLanguages = new Set<string>();
-  for (const track of prioritized) {
-    const language = normalizeLanguageTag(track.audioLocale) || `und-${track.itag}`;
-    if (seenLanguages.has(language)) continue;
-    selected.push(track);
-    seenLanguages.add(language);
-    if (selected.length >= maxCompactAudioTracks) break;
-  }
-
-  return selected.length > 0 ? selected : prioritized.slice(0, maxCompactAudioTracks);
 }
 
 function fallbackSrc(
@@ -86,6 +52,24 @@ function fallbackSrc(
   };
 }
 
+function pickCompatibleProgressiveSrc(stream: VideoStream): MediaSrc | null {
+  const progressive = [...(stream.videoStreams ?? [])]
+    .filter(
+      (candidate) =>
+        typeof candidate.codec === "string" &&
+        candidate.codec.includes("avc1") &&
+        candidate.codec.includes("mp4a") &&
+        candidate.mimeType.includes("video/mp4"),
+    )
+    .sort((left, right) => (right.bitrate ?? 0) - (left.bitrate ?? 0))[0];
+
+  if (!progressive) return null;
+  return {
+    src: proxyDashManifest(progressive.url),
+    type: "video/mp4",
+  };
+}
+
 function hasCompatibleMp4(stream: VideoStream): boolean {
   const videos = stream.videoOnlyStreams ?? [];
   const audios = stream.audioStreams ?? [];
@@ -112,7 +96,8 @@ export function resolveManifestSrc(
   options?: ResolveManifestOptions,
 ): MediaSrc {
   const isShort = Boolean(stream.isShortFormContent) || stream.id.includes("/shorts/");
-  const preferNativeManifest = options?.preferNativeManifest ?? !isShort;
+  const compatibilityMode = options?.compatibilityMode ?? isCompatibilityPlaybackMode();
+  const preferNativeManifest = (options?.preferNativeManifest ?? !isShort) && !compatibilityMode;
   const compactAudioTracks = options?.compactAudioTracks ?? isShort;
   const maxCompactAudioTracks = options?.maxCompactAudioTracks ?? (isShort ? 3 : 8);
   const provider = detectProvider(stream.id);
@@ -144,12 +129,18 @@ export function resolveManifestSrc(
     };
   }
 
+  if (!isLive && compatibilityMode) {
+    const progressiveSrc = pickCompatibleProgressiveSrc(stream);
+    if (progressiveSrc) return progressiveSrc;
+  }
+
   if (
     !isLive &&
     stream.videoOnlyStreams?.length &&
     !nativeFailed &&
     preferNativeManifest &&
-    !isFirefox
+    !isFirefox &&
+    !compatibilityMode
   ) {
     return {
       src: proxyDashManifest(

--- a/apps/web/src/settings/settings-playback.tsx
+++ b/apps/web/src/settings/settings-playback.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { usePlaybackMode } from "../hooks/use-playback-mode";
 import { useSettings } from "../hooks/use-settings";
 
 const SECTION_LABEL = "text-xs font-medium text-fg-soft uppercase tracking-wider px-1";
@@ -78,6 +79,8 @@ function QualityDropdown({ value, onChange }: DropdownProps) {
 
 export function SettingsPlayback() {
   const { settings, update } = useSettings();
+  const { playbackMode, setMode } = usePlaybackMode();
+  const compatibilityMode = playbackMode === "ios-legacy-compat";
 
   return (
     <section className="flex flex-col gap-3">
@@ -113,6 +116,29 @@ export function SettingsPlayback() {
             value={settings.defaultQuality}
             onChange={(q) => update.mutate({ defaultQuality: q })}
           />
+        </div>
+        <div className={ROW}>
+          <div className="flex flex-col gap-1">
+            <span className="text-sm text-fg">Compatibility playback mode</span>
+            <span className="text-xs text-fg-soft">
+              Prioritize reliable iOS legacy playback over adaptive behavior
+            </span>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={compatibilityMode}
+            onClick={() => setMode(compatibilityMode ? "adaptive" : "ios-legacy-compat")}
+            className={`relative w-10 h-5 rounded-full transition-colors duration-200 flex-shrink-0 ml-6 ${
+              compatibilityMode ? "bg-fg" : "bg-surface-soft"
+            }`}
+          >
+            <span
+              className={`absolute left-0.5 top-0.5 w-4 h-4 rounded-full transition-all duration-200 ${
+                compatibilityMode ? "translate-x-5 bg-surface" : "translate-x-0 bg-surface-soft"
+              }`}
+            />
+          </button>
         </div>
       </div>
     </section>

--- a/apps/web/src/types/stream.ts
+++ b/apps/web/src/types/stream.ts
@@ -34,6 +34,7 @@ export type VideoStream = {
   category?: string;
   shortDescription?: string;
   related?: VideoStream[];
+  videoStreams?: VideoStreamItem[];
   videoOnlyStreams?: VideoStreamItem[];
   audioStreams?: AudioStreamItem[];
   originalAudioTrackId?: string | null;


### PR DESCRIPTION
## Summary
- add a user-controlled playback mode toggle in Settings so compatibility behavior is explicit and not hidden behind automatic fallback
- persist playback mode locally and wire stream source resolution to prefer progressive MP4 in compatibility mode while preserving adaptive behavior in standard mode
- map `videoStreams` into frontend stream data and extract compact-audio selection into a dedicated helper module

## Commits
- feat: add playback mode toggle in settings
- fix: add compatibility source selection mode

## Validation
- bun run check
- bun run build