### PR TITLE
feat: improve watch timecodes and search overlay UX

### DIFF
--- a/apps/web/src/components/rich-text.tsx
+++ b/apps/web/src/components/rich-text.tsx
@@ -1,10 +1,27 @@
 import { useState } from "react";
 import { ExternalLinkModal } from "./external-link-modal";
 
-type Segment = { id: string } & ({ type: "text"; value: string } | { type: "url"; value: string });
+type Segment =
+  | { id: string; type: "text"; value: string }
+  | { id: string; type: "url"; value: string }
+  | { id: string; type: "timecode"; value: string; seconds: number };
+
+function parseTimestampToSeconds(value: string): number | null {
+  const parts = value.split(":").map((part) => Number(part));
+  if (parts.some((part) => !Number.isFinite(part))) return null;
+  if (parts.length === 2) {
+    const [minutes, seconds] = parts;
+    return minutes * 60 + seconds;
+  }
+  if (parts.length === 3) {
+    const [hours, minutes, seconds] = parts;
+    return hours * 3600 + minutes * 60 + seconds;
+  }
+  return null;
+}
 
 function parseSegments(text: string): Segment[] {
-  const regex = /https?:\/\/[^\s\])"',;:!>]+/g;
+  const regex = /https?:\/\/[^\s\])"',;:!>]+|\b(?:\d{1,2}:)?[0-5]?\d:[0-5]\d\b/g;
   const segments: Segment[] = [];
   let lastIndex = 0;
   let counter = 0;
@@ -17,7 +34,17 @@ function parseSegments(text: string): Segment[] {
         value: text.slice(lastIndex, match.index),
       });
     }
-    segments.push({ id: `u${counter++}`, type: "url", value: match[0] });
+    const value = match[0];
+    if (value.startsWith("http://") || value.startsWith("https://")) {
+      segments.push({ id: `u${counter++}`, type: "url", value });
+    } else {
+      const seconds = parseTimestampToSeconds(value);
+      if (seconds === null) {
+        segments.push({ id: `t${counter++}`, type: "text", value });
+      } else {
+        segments.push({ id: `c${counter++}`, type: "timecode", value, seconds });
+      }
+    }
     lastIndex = match.index + match[0].length;
     match = regex.exec(text);
   }
@@ -27,9 +54,12 @@ function parseSegments(text: string): Segment[] {
   return segments;
 }
 
-type Props = { text: string };
+type RichTextProps = {
+  text: string;
+  onSeekTimestamp?: (seconds: number) => void;
+};
 
-export function RichText({ text }: Props) {
+export function RichText({ text, onSeekTimestamp }: RichTextProps) {
   const [pendingUrl, setPendingUrl] = useState<string | null>(null);
   const segments = parseSegments(text);
 
@@ -38,7 +68,7 @@ export function RichText({ text }: Props) {
       {segments.map((seg) =>
         seg.type === "text" ? (
           <span key={seg.id}>{seg.value}</span>
-        ) : (
+        ) : seg.type === "url" ? (
           <a
             key={seg.id}
             href={seg.value}
@@ -50,6 +80,17 @@ export function RichText({ text }: Props) {
           >
             {seg.value}
           </a>
+        ) : onSeekTimestamp ? (
+          <button
+            key={seg.id}
+            type="button"
+            onClick={() => onSeekTimestamp(seg.seconds)}
+            className="text-accent hover:text-accent-strong underline underline-offset-2 transition-colors"
+          >
+            {seg.value}
+          </button>
+        ) : (
+          <span key={seg.id}>{seg.value}</span>
         ),
       )}
       {pendingUrl && (

--- a/apps/web/src/components/search-overlay-list.tsx
+++ b/apps/web/src/components/search-overlay-list.tsx
@@ -1,9 +1,5 @@
 import type { RefObject } from "react";
-
-export type SearchOverlayItem = {
-  key: string;
-  label: string;
-};
+import type { SearchOverlayItem } from "../lib/search-overlay-items";
 
 type Props = {
   items: SearchOverlayItem[];
@@ -60,7 +56,14 @@ export function SearchOverlayList({
             }`}
             onClick={() => onSelect(item.label)}
           >
-            {item.label}
+            <span className="inline-flex items-center gap-2">
+              <span>{item.label}</span>
+              {item.source === "history" && !showHistory && (
+                <span className="rounded-md border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-fg-soft">
+                  History
+                </span>
+              )}
+            </span>
           </button>
         </li>
       ))}

--- a/apps/web/src/components/search-overlay.tsx
+++ b/apps/web/src/components/search-overlay.tsx
@@ -1,10 +1,15 @@
+import { useRouterState } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { useDebouncedValue } from "../hooks/use-debounced-value";
 import { useSearchHistory } from "../hooks/use-search-history";
 import { useSearchOverlayNavigation } from "../hooks/use-search-overlay-navigation";
 import { fetchSuggestions } from "../lib/api";
+import { buildSearchOverlayItems } from "../lib/search-overlay-items";
+import {
+  resolveInitialSearchOverlayQuery,
+  writeSearchOverlayQuery,
+} from "../lib/search-overlay-query";
 import { ConfirmModal } from "./confirm-modal";
-import type { SearchOverlayItem } from "./search-overlay-list";
 import { SearchOverlayList } from "./search-overlay-list";
 
 type Props = {
@@ -12,7 +17,10 @@ type Props = {
 };
 
 export function SearchOverlay({ onClose }: Props) {
-  const [query, setQuery] = useState("");
+  const location = useRouterState({ select: (state) => state.location });
+  const [query, setQuery] = useState(() =>
+    resolveInitialSearchOverlayQuery(location.pathname, location.searchStr),
+  );
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [confirmClearOpen, setConfirmClearOpen] = useState(false);
@@ -21,6 +29,7 @@ export function SearchOverlay({ onClose }: Props) {
   const { service, navigateAndClose } = useSearchOverlayNavigation({ onClose });
   const { visibleItems, canLoadMore, loadMore, clear } = useSearchHistory();
   const debouncedQuery = useDebouncedValue(query, 300);
+  const items = buildSearchOverlayItems(query, visibleItems, suggestions);
 
   useEffect(() => {
     const frame = requestAnimationFrame(() => inputRef.current?.focus());
@@ -59,31 +68,32 @@ export function SearchOverlay({ onClose }: Props) {
     element?.scrollIntoView({ block: "nearest", behavior: "smooth" });
   }, [selectedIndex]);
 
-  const showSuggestions = query.trim().length > 0 && suggestions.length > 0;
   const showHistory = query.trim().length === 0 && visibleItems.length > 0;
-  const items: SearchOverlayItem[] = showHistory
-    ? visibleItems.map((item) => ({ key: item.id, label: item.term }))
-    : showSuggestions
-      ? suggestions.slice(0, 8).map((term) => ({ key: term, label: term }))
-      : [];
+
+  function submitTerm(term: string) {
+    const trimmed = term.trim();
+    if (!trimmed) return;
+    writeSearchOverlayQuery(trimmed);
+    navigateAndClose(trimmed);
+  }
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (selectedIndex >= 0 && items[selectedIndex]) {
-      navigateAndClose(items[selectedIndex].label);
+      submitTerm(items[selectedIndex].label);
       return;
     }
-    if (!query.trim()) return;
-    navigateAndClose(query.trim());
+    submitTerm(query);
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (items.length === 0) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setSelectedIndex((i) => Math.min(i + 1, items.length - 1));
+      setSelectedIndex((index) => (index >= items.length - 1 ? 0 : index + 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
-      setSelectedIndex((i) => Math.max(i - 1, -1));
+      setSelectedIndex((index) => (index <= 0 ? items.length - 1 : index - 1));
     }
   }
 
@@ -122,6 +132,7 @@ export function SearchOverlay({ onClose }: Props) {
             value={query}
             onChange={(e) => {
               setQuery(e.target.value);
+              writeSearchOverlayQuery(e.target.value);
               setSelectedIndex(-1);
             }}
             onKeyDown={handleKeyDown}
@@ -136,7 +147,7 @@ export function SearchOverlay({ onClose }: Props) {
           listRef={listRef}
           onScroll={handleHistoryScroll}
           onClearAll={() => setConfirmClearOpen(true)}
-          onSelect={navigateAndClose}
+          onSelect={submitTerm}
         />
       </div>
       {confirmClearOpen && (

--- a/apps/web/src/components/watch-description.tsx
+++ b/apps/web/src/components/watch-description.tsx
@@ -3,9 +3,10 @@ import { RichText } from "./rich-text";
 
 type Props = {
   description: string;
+  onSeekTimestamp?: (seconds: number) => void;
 };
 
-export function WatchDescription({ description }: Props) {
+export function WatchDescription({ description, onSeekTimestamp }: Props) {
   const [expanded, setExpanded] = useState(false);
 
   if (!expanded) {
@@ -26,7 +27,7 @@ export function WatchDescription({ description }: Props) {
   return (
     <div className="bg-surface rounded-xl px-4 py-3">
       <p className="text-sm text-fg leading-relaxed whitespace-pre-wrap">
-        <RichText text={description} />
+        <RichText text={description} onSeekTimestamp={onSeekTimestamp} />
       </p>
       <button
         type="button"

--- a/apps/web/src/components/watch-layout.tsx
+++ b/apps/web/src/components/watch-layout.tsx
@@ -144,7 +144,9 @@ export function WatchLayout({ stream, startTime }: Props) {
           />
           {playerFailed && <PlayerError onRetry={reset} />}
         </div>
-        {!cinemaMode && <WatchMeta stream={stream} />}
+        {!cinemaMode && (
+          <WatchMeta stream={stream} onSeekTimestamp={(seconds) => seekRef.current?.(seconds)} />
+        )}
       </div>
       {!cinemaMode && (
         <div className="w-full lg:flex-1 lg:min-w-64 flex flex-col gap-6">
@@ -154,7 +156,7 @@ export function WatchLayout({ stream, startTime }: Props) {
       {cinemaMode && (
         <div className="mx-auto flex w-full max-w-[1700px] flex-col gap-6 px-4 lg:flex-row lg:items-start">
           <div className="min-w-0 flex-[2] max-w-[1200px] flex flex-col gap-4">
-            <WatchMeta stream={stream} />
+            <WatchMeta stream={stream} onSeekTimestamp={(seconds) => seekRef.current?.(seconds)} />
           </div>
           <div className="w-full lg:flex-1 lg:min-w-64">
             <RelatedVideos streams={relatedStreams} />

--- a/apps/web/src/components/watch-meta.tsx
+++ b/apps/web/src/components/watch-meta.tsx
@@ -7,14 +7,17 @@ import { WatchInfo } from "./watch-info";
 type Props = {
   stream: VideoStream;
   showComments?: boolean;
+  onSeekTimestamp?: (seconds: number) => void;
 };
 
-export function WatchMeta({ stream, showComments = true }: Props) {
+export function WatchMeta({ stream, showComments = true, onSeekTimestamp }: Props) {
   return (
     <>
       <WatchInfo stream={stream} />
       <WatchActions stream={stream} />
-      {stream.description && <WatchDescription description={stream.description} />}
+      {stream.description && (
+        <WatchDescription description={stream.description} onSeekTimestamp={onSeekTimestamp} />
+      )}
       {showComments && <WatchComments key={stream.id} videoUrl={stream.id} />}
     </>
   );

--- a/apps/web/src/lib/search-overlay-items.ts
+++ b/apps/web/src/lib/search-overlay-items.ts
@@ -1,0 +1,47 @@
+import type { SearchHistoryItem } from "../types/user";
+
+export type SearchOverlayItem = {
+  key: string;
+  label: string;
+  source: "history" | "suggestion";
+};
+
+const LIMIT = 10;
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function dedupeItems(items: SearchOverlayItem[]): SearchOverlayItem[] {
+  const result: SearchOverlayItem[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    const id = normalize(item.label);
+    if (seen.has(id)) continue;
+    seen.add(id);
+    result.push(item);
+    if (result.length >= LIMIT) break;
+  }
+  return result;
+}
+
+export function buildSearchOverlayItems(
+  query: string,
+  historyItems: SearchHistoryItem[],
+  suggestions: string[],
+): SearchOverlayItem[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return historyItems.map((item) => ({ key: item.id, label: item.term, source: "history" }));
+  }
+  const normalized = normalize(trimmed);
+  const historyMatches = historyItems
+    .filter((item) => normalize(item.term).startsWith(normalized))
+    .map((item) => ({ key: `h-${item.id}`, label: item.term, source: "history" as const }));
+  const suggestionItems = suggestions.map((term, index) => ({
+    key: `s-${normalize(term)}-${index}`,
+    label: term,
+    source: "suggestion" as const,
+  }));
+  return dedupeItems([...historyMatches, ...suggestionItems]);
+}

--- a/apps/web/src/lib/search-overlay-query.ts
+++ b/apps/web/src/lib/search-overlay-query.ts
@@ -1,0 +1,28 @@
+const KEY = "typed-search-overlay-query";
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function readSearchOverlayQuery(): string {
+  if (!canUseStorage()) return "";
+  return window.localStorage.getItem(KEY) ?? "";
+}
+
+export function writeSearchOverlayQuery(value: string): void {
+  if (!canUseStorage()) return;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    window.localStorage.removeItem(KEY);
+    return;
+  }
+  window.localStorage.setItem(KEY, trimmed);
+}
+
+export function resolveInitialSearchOverlayQuery(pathname: string, searchStr: string): string {
+  if (pathname === "/search") {
+    const q = new URLSearchParams(searchStr).get("q") ?? "";
+    if (q.trim().length > 0) return q.trim();
+  }
+  return readSearchOverlayQuery();
+}

--- a/apps/web/src/lib/search-overlay-query.ts
+++ b/apps/web/src/lib/search-overlay-query.ts
@@ -4,7 +4,7 @@ function canUseStorage(): boolean {
   return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
 }
 
-export function readSearchOverlayQuery(): string {
+function readSearchOverlayQuery(): string {
   if (!canUseStorage()) return "";
   return window.localStorage.getItem(KEY) ?? "";
 }


### PR DESCRIPTION
## Summary
- make watch description timestamps clickable (`mm:ss`/`hh:mm:ss`) and seek the active player directly from description text
- keep search overlay query state between opens, seed it from the current `/search?q=` when available, and support quick query refinement without retyping
- merge matching search history with live suggestions, prioritize history matches, show a history badge, and improve arrow-key cycling behavior

## Commits
- feat: improve search overlay history and keyboard flow
- feat: support clickable description timecodes

## Validation
- bun run check
- bun run build