### PR TITLE
fix: harden playback fallback path on Firefox

### DIFF
--- a/apps/web/src/hooks/use-player-error.ts
+++ b/apps/web/src/hooks/use-player-error.ts
@@ -39,16 +39,21 @@ export function usePlayerError(stream: VideoStream, isLive: boolean): UsePlayerE
   const nativeEnabled = !isLive && Boolean(stream.videoOnlyStreams?.length) && preferNativeManifest;
   const [nativeFailed, setNativeFailed] = useState(false);
   const [qualityFailed, setQualityFailed] = useState(false);
+  const [compatibilityFallback, setCompatibilityFallback] = useState(false);
   const [playerFailed, setPlayerFailed] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
 
-  const manifestSrc = useMemo(
-    () =>
-      resolveManifestSrc(stream, isLive, nativeFailed, qualityFailed, {
+  const manifestSrc = useMemo(() => {
+    if (compatibilityFallback) {
+      return resolveManifestSrc(stream, isLive, nativeFailed, qualityFailed, {
         preferNativeManifest,
-      }),
-    [stream, isLive, nativeFailed, qualityFailed, preferNativeManifest],
-  );
+        compatibilityMode: true,
+      });
+    }
+    return resolveManifestSrc(stream, isLive, nativeFailed, qualityFailed, {
+      preferNativeManifest,
+    });
+  }, [stream, isLive, nativeFailed, qualityFailed, preferNativeManifest, compatibilityFallback]);
 
   const handleError = useCallback(() => {
     if (nativeEnabled && !nativeFailed) {
@@ -59,15 +64,20 @@ export function usePlayerError(stream: VideoStream, isLive: boolean): UsePlayerE
       recordClientEvent("player.quality_failed", { video: debugVideo });
       setQualityFailed(true);
       setRetryKey((k) => k + 1);
+    } else if (!isLive && !compatibilityFallback) {
+      recordClientEvent("player.compatibility_fallback", { video: debugVideo });
+      setCompatibilityFallback(true);
+      setRetryKey((k) => k + 1);
     } else {
       recordClientEvent("player.failed", { video: debugVideo });
       setPlayerFailed(true);
     }
-  }, [debugVideo, nativeEnabled, nativeFailed, qualityFailed]);
+  }, [debugVideo, nativeEnabled, nativeFailed, qualityFailed, compatibilityFallback, isLive]);
 
   const reset = useCallback(() => {
     setNativeFailed(false);
     setQualityFailed(false);
+    setCompatibilityFallback(false);
     setPlayerFailed(false);
     setRetryKey((k) => k + 1);
   }, []);
@@ -76,6 +86,7 @@ export function usePlayerError(stream: VideoStream, isLive: boolean): UsePlayerE
     if (streamId.length === 0) return;
     setNativeFailed(false);
     setQualityFailed(false);
+    setCompatibilityFallback(false);
     setPlayerFailed(false);
     setRetryKey(0);
   }, [streamId]);

--- a/apps/web/src/hooks/use-player-error.ts
+++ b/apps/web/src/hooks/use-player-error.ts
@@ -32,11 +32,20 @@ function hasMultipleAudioLanguages(stream: VideoStream): boolean {
   return false;
 }
 
+function isFirefoxBrowser(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return navigator.userAgent.includes("Firefox/");
+}
+
 export function usePlayerError(stream: VideoStream, isLive: boolean): UsePlayerErrorReturn {
   const streamId = stream.id;
   const debugVideo = sanitizeVideoContext(streamId) ?? "unknown";
   const preferNativeManifest = !isIosDevice() && !hasMultipleAudioLanguages(stream);
-  const nativeEnabled = !isLive && Boolean(stream.videoOnlyStreams?.length) && preferNativeManifest;
+  const nativeEnabled =
+    !isLive &&
+    !isFirefoxBrowser() &&
+    Boolean(stream.videoOnlyStreams?.length) &&
+    preferNativeManifest;
   const [nativeFailed, setNativeFailed] = useState(false);
   const [qualityFailed, setQualityFailed] = useState(false);
   const [compatibilityFallback, setCompatibilityFallback] = useState(false);

--- a/apps/web/src/lib/stream-src.ts
+++ b/apps/web/src/lib/stream-src.ts
@@ -129,7 +129,7 @@ export function resolveManifestSrc(
     };
   }
 
-  if (!isLive && compatibilityMode) {
+  if (!isLive && (compatibilityMode || isFirefox)) {
     const progressiveSrc = pickCompatibleProgressiveSrc(stream);
     if (progressiveSrc) return progressiveSrc;
   }


### PR DESCRIPTION
## Summary
- add a third-stage player recovery path that retries with compatibility playback mode before surfacing a terminal error
- prefer progressive MP4 sources for non-live Firefox playback to avoid unstable DASH decode/reset loops
- keep player fallback state reset behavior deterministic across retries and video changes