### PR TITLE
fix: remove Firefox automatic playback fallback

### DIFF
--- a/apps/web/src/hooks/use-player-error.ts
+++ b/apps/web/src/hooks/use-player-error.ts
@@ -32,20 +32,11 @@ function hasMultipleAudioLanguages(stream: VideoStream): boolean {
   return false;
 }
 
-function isFirefoxBrowser(): boolean {
-  if (typeof navigator === "undefined") return false;
-  return navigator.userAgent.includes("Firefox/");
-}
-
 export function usePlayerError(stream: VideoStream, isLive: boolean): UsePlayerErrorReturn {
   const streamId = stream.id;
   const debugVideo = sanitizeVideoContext(streamId) ?? "unknown";
   const preferNativeManifest = !isIosDevice() && !hasMultipleAudioLanguages(stream);
-  const nativeEnabled =
-    !isLive &&
-    !isFirefoxBrowser() &&
-    Boolean(stream.videoOnlyStreams?.length) &&
-    preferNativeManifest;
+  const nativeEnabled = !isLive && Boolean(stream.videoOnlyStreams?.length) && preferNativeManifest;
   const [nativeFailed, setNativeFailed] = useState(false);
   const [qualityFailed, setQualityFailed] = useState(false);
   const [compatibilityFallback, setCompatibilityFallback] = useState(false);

--- a/apps/web/src/lib/stream-src.ts
+++ b/apps/web/src/lib/stream-src.ts
@@ -129,7 +129,7 @@ export function resolveManifestSrc(
     };
   }
 
-  if (!isLive && (compatibilityMode || isFirefox)) {
+  if (!isLive && compatibilityMode) {
     const progressiveSrc = pickCompatibleProgressiveSrc(stream);
     if (progressiveSrc) return progressiveSrc;
   }


### PR DESCRIPTION
## Summary
- remove the automatic Firefox-specific progressive fallback in source resolution
- restore native retry behavior in player error handling without Firefox-only gating
- keep compatibility-mode fallback available only when explicitly enabled or reached through retries