### PR TITLE
fix: surface failed delete responses

### DIFF
--- a/apps/web/src/lib/api-collections.ts
+++ b/apps/web/src/lib/api-collections.ts
@@ -4,6 +4,12 @@ import { authed, authedJson } from "./authed";
 
 import { API_BASE as BASE } from "./env";
 
+async function throwIfFailed(res: Response, fallback: string): Promise<void> {
+  if (res.ok) return;
+  const body = await res.json().catch(() => ({ error: fallback }));
+  throw new ApiError((body as { error: string }).error, res.status);
+}
+
 export async function fetchProgress(videoUrl: string): Promise<ProgressItem> {
   const res = await authed(`${BASE}/progress/${encodeURIComponent(videoUrl)}`);
   if (res.status === 404) return { videoUrl, position: 0, updatedAt: 0 };
@@ -42,7 +48,10 @@ export async function blockChannel(
 }
 
 export async function unblockChannel(url: string): Promise<void> {
-  await authed(`${BASE}/blocked/channels/${encodeURIComponent(url)}`, { method: "DELETE" });
+  const res = await authed(`${BASE}/blocked/channels/${encodeURIComponent(url)}`, {
+    method: "DELETE",
+  });
+  await throwIfFailed(res, "unblock failed");
 }
 
 export function fetchBlockedVideos(): Promise<BlockedItem[]> {
@@ -58,5 +67,8 @@ export async function blockVideo(url: string, global = false): Promise<void> {
 }
 
 export async function unblockVideo(url: string): Promise<void> {
-  await authed(`${BASE}/blocked/videos/${encodeURIComponent(url)}`, { method: "DELETE" });
+  const res = await authed(`${BASE}/blocked/videos/${encodeURIComponent(url)}`, {
+    method: "DELETE",
+  });
+  await throwIfFailed(res, "unblock failed");
 }

--- a/apps/web/src/lib/api-playlists.ts
+++ b/apps/web/src/lib/api-playlists.ts
@@ -50,7 +50,7 @@ export async function removeVideoFromPlaylist(playlistId: string, videoUrl: stri
     `${BASE}/playlists/${encodeURIComponent(playlistId)}/videos/${encodeURIComponent(videoUrl)}`,
     { method: "DELETE" },
   );
-  if (!res.ok && res.status !== 404) {
+  if (!res.ok) {
     const body = await res.json().catch(() => ({ error: "remove failed" }));
     throw new ApiError((body as { error: string }).error, res.status);
   }


### PR DESCRIPTION
## Summary
- stop treating playlist video delete 404 responses as successful removals
- surface failed blocked channel/video delete responses instead of silently accepting them

## Validation
- bun run check
- bun run knip
- bun run sherif
- bun run build