### PR TITLE
fix: upgrade runtime libxml2 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN bun run --cwd apps/web build
 
 FROM nginx:1.31.0-alpine AS runner
 
+RUN apk upgrade --no-cache libxml2
+
 COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Summary
- Upgrade the runtime image libxml2 package during the frontend image build.
- Clear the Trivy HIGH finding for CVE-2026-6732 before production redeploy.

Validation
- bun run check
- git diff --check
- Trivy reported CVE-2026-6732 against ghcr.io/priveetee/typetype:latest before this fix