### PR TITLE
chore: publish multi-arch docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,11 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref_name == 'dev' }}
             type=raw,value=beta,enable=${{ github.ref_name == 'dev' }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.0.0
 
@@ -56,6 +61,7 @@ jobs:
         uses: docker/build-push-action@v7.1.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           pull: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.14-alpine AS builder
+FROM --platform=$BUILDPLATFORM oven/bun:1.3.14-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- publish the TypeType frontend Docker image for both `linux/amd64` and `linux/arm64`
- set up QEMU for ARM64 Docker builds
- keep the Bun build stage on the native build platform

Closes https://github.com/Priveetee/TypeType/issues/48

## Verification
- `bun install --frozen-lockfile`
- `bun run check`
- `bun run knip`
- `bun run sherif`
- `bun run build`
- local ARM64 smoke: `docker buildx build --builder typetype-multiarch-local --platform linux/arm64 -t typetype-frontend:arm64-local --load .`
- local ARM64 runtime: `docker run --rm --platform linux/arm64 --entrypoint nginx typetype-frontend:arm64-local -v`