### PR TITLE
feat: clean public watch and channel URLs

### DIFF
--- a/apps/web/src/components/channel-page-content.tsx
+++ b/apps/web/src/components/channel-page-content.tsx
@@ -1,0 +1,146 @@
+import { useBlockedFilter } from "../hooks/use-blocked-filter";
+import { useChannel } from "../hooks/use-channel";
+import { useDocumentTitle } from "../hooks/use-document-title";
+import { useSubscriptions } from "../hooks/use-subscriptions";
+import { ApiError, type ChannelSort } from "../lib/api";
+import { formatViews } from "../lib/format";
+import { detectProvider } from "../lib/provider";
+import { ChannelAvatar } from "./channel-avatar";
+import { ChannelFilterBar } from "./channel-filter-bar";
+import { ChannelPodcastsSection } from "./channel-podcasts-section";
+import { PageSpinner } from "./page-spinner";
+import { ScrollSentinel } from "./scroll-sentinel";
+import { VideoCard } from "./video-card";
+import { VideoGridSkeleton } from "./video-grid-skeleton";
+import { VerifiedBadgeIcon } from "./watch-icons";
+
+type Props = {
+  sourceUrl: string;
+  sort: ChannelSort;
+  searchQuery: string;
+  onNavigate: (sort: ChannelSort, query: string) => void;
+};
+
+export function ChannelPageContent({ sourceUrl, sort, searchQuery, onNavigate }: Props) {
+  const {
+    meta,
+    videos,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    hasNextPage,
+    isFetching,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useChannel(sourceUrl, sort, searchQuery);
+  const { add, remove, isSubscribed } = useSubscriptions();
+  const { filter } = useBlockedFilter();
+  useDocumentTitle(meta?.name);
+
+  const subscribed = isSubscribed(sourceUrl);
+  const searchAvailable = detectProvider(sourceUrl) === "youtube";
+  const visibleVideos = filter(videos);
+  const isInitialLoading = isLoading && !meta;
+  const isReplacingVideos = isFetching && !isFetchingNextPage && visibleVideos.length === 0;
+
+  function handleSubscribe() {
+    if (!meta) return;
+    if (subscribed) {
+      remove.mutate(sourceUrl);
+    } else {
+      add.mutate({ channelUrl: sourceUrl, name: meta.name, avatarUrl: meta.avatarUrl });
+    }
+  }
+
+  function selectSort(nextSort: ChannelSort) {
+    onNavigate(nextSort, searchQuery);
+  }
+
+  function searchChannel(nextQuery: string) {
+    onNavigate(sort, searchAvailable ? nextQuery : "");
+  }
+
+  if (isInitialLoading) return <PageSpinner />;
+  if (isError) {
+    const message = error instanceof ApiError ? error.message : "Unable to load channel right now.";
+    return (
+      <div className="rounded-xl border border-border bg-surface p-6 flex flex-col gap-3 max-w-xl">
+        <p className="text-sm text-fg">{message}</p>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="h-9 w-fit rounded-md bg-fg px-3 text-xs font-medium text-app hover:bg-white"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {meta && (
+        <div className="flex flex-col gap-4">
+          {meta.bannerUrl && (
+            <img src={meta.bannerUrl} alt="" className="w-full h-32 object-cover rounded-lg" />
+          )}
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-4">
+              <ChannelAvatar src={meta.avatarUrl} name={meta.name} className="w-14 h-14" />
+              <div className="flex flex-col">
+                <h1 className="text-lg font-semibold text-fg flex items-center gap-1.5">
+                  {meta.name}
+                  {meta.isVerified && <VerifiedBadgeIcon />}
+                </h1>
+                <p className="text-sm text-fg-soft">
+                  {formatViews(meta.subscriberCount)} subscribers
+                </p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={handleSubscribe}
+              aria-pressed={subscribed}
+              className={`px-4 py-1.5 text-sm font-medium rounded-full transition-colors ${
+                subscribed
+                  ? "ring-1 ring-border-strong bg-surface-strong text-fg hover:bg-surface-soft"
+                  : "bg-fg text-app hover:bg-white"
+              }`}
+            >
+              {subscribed ? "Subscribed" : "Subscribe"}
+            </button>
+          </div>
+        </div>
+      )}
+      <ChannelPodcastsSection channelUrl={sourceUrl} channelAvatar={meta?.avatarUrl} />
+      <ChannelFilterBar
+        sort={sort}
+        query={searchQuery}
+        searchAvailable={searchAvailable}
+        onSearch={searchChannel}
+        onSortChange={selectSort}
+      />
+      {isReplacingVideos ? (
+        <VideoGridSkeleton idPrefix="channel-replace" />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-4 gap-y-8">
+          {visibleVideos.map((v, index) => (
+            <div
+              key={v.id}
+              className="animate-card-pop-in"
+              style={{ animationDelay: `${Math.min(index * 45, 270)}ms` }}
+            >
+              <VideoCard stream={v} />
+            </div>
+          ))}
+        </div>
+      )}
+      {isFetchingNextPage && <VideoGridSkeleton idPrefix="channel-next" />}
+      <ScrollSentinel
+        onIntersect={fetchNextPage}
+        enabled={hasNextPage && !isFetchingNextPage && !isReplacingVideos}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/channel-route-link.tsx
+++ b/apps/web/src/components/channel-route-link.tsx
@@ -1,0 +1,39 @@
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import type { ChannelSort } from "../lib/api";
+import {
+  channelLegacySearch,
+  channelPathSearch,
+  toChannelPathParam,
+} from "../lib/channel-route-url";
+
+type Props = {
+  url: string;
+  children: ReactNode;
+  className?: string;
+  sort?: ChannelSort;
+  query?: string;
+};
+
+export function ChannelRouteLink({ url, children, className, sort = "latest", query = "" }: Props) {
+  const channelId = toChannelPathParam(url);
+
+  if (channelId) {
+    return (
+      <Link
+        to="/channel/$channelId"
+        params={{ channelId }}
+        search={channelPathSearch(sort, query)}
+        className={className}
+      >
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <Link to="/channel" search={channelLegacySearch(url, sort, query)} className={className}>
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/src/components/continue-card.tsx
+++ b/apps/web/src/components/continue-card.tsx
@@ -4,7 +4,9 @@ import { useWatchPrefetch } from "../hooks/use-watch-prefetch";
 import { formatDuration } from "../lib/format";
 import { resolveHistoryChannelMeta } from "../lib/history-enrichment";
 import { proxyImage } from "../lib/proxy";
+import { watchRouteSearch } from "../lib/watch-url";
 import type { HistoryItem } from "../types/user";
+import { ChannelRouteLink } from "./channel-route-link";
 import { HistoryChannelAvatar } from "./history-channel-avatar";
 import { VideoProgressBar } from "./video-progress-bar";
 import { VerifiedBadgeIcon } from "./watch-icons";
@@ -37,7 +39,7 @@ export function ContinueCard({ item }: ContinueCardProps) {
     <div className="w-44 flex-shrink-0">
       <Link
         to="/watch"
-        search={{ v: item.url }}
+        search={watchRouteSearch(item.url)}
         className="group flex flex-col gap-2"
         onMouseEnter={prefetch.onMouseEnter}
         onMouseLeave={prefetch.onMouseLeave}
@@ -61,21 +63,20 @@ export function ContinueCard({ item }: ContinueCardProps) {
       </Link>
       <div className="mt-1.5 flex min-w-0 items-center gap-1.5">
         {item.channelUrl ? (
-          <Link to="/channel" search={{ url: item.channelUrl }} className="flex-shrink-0">
+          <ChannelRouteLink url={item.channelUrl} className="flex-shrink-0">
             <HistoryChannelAvatar item={item} className="h-5 w-5" />
-          </Link>
+          </ChannelRouteLink>
         ) : (
           <HistoryChannelAvatar item={item} className="h-5 w-5" />
         )}
         {item.channelUrl ? (
-          <Link
-            to="/channel"
-            search={{ url: item.channelUrl }}
+          <ChannelRouteLink
+            url={item.channelUrl}
             className="flex min-w-0 items-center gap-1 text-[10px] text-fg-soft transition-colors hover:text-fg"
           >
             <span className="min-w-0 truncate">{item.channelName}</span>
             {uploaderVerified && <VerifiedBadgeIcon />}
-          </Link>
+          </ChannelRouteLink>
         ) : (
           <span className="flex min-w-0 items-center gap-1 text-[10px] text-fg-soft">
             <span className="min-w-0 truncate">{item.channelName}</span>

--- a/apps/web/src/components/history-card.tsx
+++ b/apps/web/src/components/history-card.tsx
@@ -2,7 +2,9 @@ import { Link } from "@tanstack/react-router";
 import { useWatchPrefetch } from "../hooks/use-watch-prefetch";
 import { formatDuration } from "../lib/format";
 import { proxyImage } from "../lib/proxy";
+import { watchRouteSearch } from "../lib/watch-url";
 import type { HistoryItem } from "../types/user";
+import { ChannelRouteLink } from "./channel-route-link";
 import { HistoryChannelAvatar } from "./history-channel-avatar";
 import { VideoProgressBar } from "./video-progress-bar";
 
@@ -50,7 +52,7 @@ export function HistoryCard({ item, onRemove, index }: HistoryCardProps) {
     >
       <Link
         to="/watch"
-        search={{ v: item.url }}
+        search={watchRouteSearch(item.url)}
         className="block"
         onMouseEnter={prefetch.onMouseEnter}
         onMouseLeave={prefetch.onMouseLeave}
@@ -84,29 +86,28 @@ export function HistoryCard({ item, onRemove, index }: HistoryCardProps) {
       </Link>
       <div className="flex gap-2">
         {item.channelUrl ? (
-          <Link to="/channel" search={{ url: item.channelUrl }} className="flex-shrink-0 mt-0.5">
+          <ChannelRouteLink url={item.channelUrl} className="flex-shrink-0 mt-0.5">
             <HistoryChannelAvatar item={item} className="w-7 h-7" />
-          </Link>
+          </ChannelRouteLink>
         ) : (
           <HistoryChannelAvatar item={item} className="w-7 h-7" />
         )}
         <div className="flex flex-col gap-0.5 min-w-0">
           <Link
             to="/watch"
-            search={{ v: item.url }}
+            search={watchRouteSearch(item.url)}
             onMouseEnter={prefetch.onMouseEnter}
             onMouseLeave={prefetch.onMouseLeave}
           >
             <p className="text-sm font-medium text-fg line-clamp-2 leading-snug">{item.title}</p>
           </Link>
           {item.channelUrl ? (
-            <Link
-              to="/channel"
-              search={{ url: item.channelUrl }}
+            <ChannelRouteLink
+              url={item.channelUrl}
               className="text-xs text-fg-muted hover:text-fg transition-colors w-fit"
             >
               {item.channelName}
-            </Link>
+            </ChannelRouteLink>
           ) : (
             <p className="text-xs text-fg-muted">{item.channelName}</p>
           )}

--- a/apps/web/src/components/notification-row.tsx
+++ b/apps/web/src/components/notification-row.tsx
@@ -3,6 +3,7 @@ import { useClientLocale } from "../hooks/use-client-locale";
 import { useWatchPrefetch } from "../hooks/use-watch-prefetch";
 import { formatPublishedDate } from "../lib/format";
 import { proxyImage } from "../lib/proxy";
+import { watchRouteSearch } from "../lib/watch-url";
 import type { NotificationItem } from "../types/notifications";
 
 type Props = {
@@ -23,7 +24,7 @@ export function NotificationRow({ item, onOpen }: Props) {
   return (
     <Link
       to="/watch"
-      search={{ v: videoId }}
+      search={watchRouteSearch(videoId)}
       className="grid grid-cols-[96px_1fr] gap-3 rounded-lg px-2 py-2 hover:bg-surface-strong [animation:card-pop-in_0.24s_ease-out]"
       onClick={onOpen}
       onMouseEnter={prefetch.onMouseEnter}

--- a/apps/web/src/components/playlist-video-row.tsx
+++ b/apps/web/src/components/playlist-video-row.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useWatchPrefetch } from "../hooks/use-watch-prefetch";
+import { watchRouteSearch } from "../lib/watch-url";
 import type { PlaylistVideoItem } from "../types/user";
 
 function XIcon() {
@@ -33,7 +34,7 @@ export function PlaylistVideoRow({ video, onRemove }: Props) {
     <div className="flex flex-col gap-2 group relative">
       <Link
         to="/watch"
-        search={{ v: video.url }}
+        search={watchRouteSearch(video.url)}
         className="block"
         onMouseEnter={prefetch.onMouseEnter}
         onMouseLeave={prefetch.onMouseLeave}
@@ -63,7 +64,7 @@ export function PlaylistVideoRow({ video, onRemove }: Props) {
       </Link>
       <Link
         to="/watch"
-        search={{ v: video.url }}
+        search={watchRouteSearch(video.url)}
         onMouseEnter={prefetch.onMouseEnter}
         onMouseLeave={prefetch.onMouseLeave}
       >

--- a/apps/web/src/components/related-card.tsx
+++ b/apps/web/src/components/related-card.tsx
@@ -1,8 +1,10 @@
 import { Link } from "@tanstack/react-router";
 import { useWatchPrefetch } from "../hooks/use-watch-prefetch";
 import { formatDuration, formatViews } from "../lib/format";
+import { watchRouteSearch } from "../lib/watch-url";
 import type { VideoStream } from "../types/stream";
 import { ChannelAvatar } from "./channel-avatar";
+import { ChannelRouteLink } from "./channel-route-link";
 import { VerifiedBadgeIcon } from "./watch-icons";
 
 type Props = {
@@ -16,7 +18,7 @@ export function RelatedCard({ stream }: Props) {
     <div className="flex gap-2 group">
       <Link
         to="/watch"
-        search={{ v: stream.id }}
+        search={watchRouteSearch(stream.id)}
         className="relative w-40 aspect-video rounded-md overflow-hidden bg-surface-strong flex-shrink-0"
         onMouseEnter={prefetch.onMouseEnter}
         onMouseLeave={prefetch.onMouseLeave}
@@ -42,7 +44,7 @@ export function RelatedCard({ stream }: Props) {
       <div className="flex flex-col gap-0.5 min-w-0 flex-1">
         <Link
           to="/watch"
-          search={{ v: stream.id }}
+          search={watchRouteSearch(stream.id)}
           className="text-xs font-medium text-fg line-clamp-2 leading-snug hover:text-white"
           onMouseEnter={prefetch.onMouseEnter}
           onMouseLeave={prefetch.onMouseLeave}
@@ -50,9 +52,8 @@ export function RelatedCard({ stream }: Props) {
           {stream.title}
         </Link>
         {stream.channelUrl ? (
-          <Link
-            to="/channel"
-            search={{ url: stream.channelUrl }}
+          <ChannelRouteLink
+            url={stream.channelUrl}
             className="flex items-center gap-1.5 mt-0.5 w-fit group/channel"
           >
             <ChannelAvatar
@@ -64,7 +65,7 @@ export function RelatedCard({ stream }: Props) {
               {stream.channelName}
               {stream.uploaderVerified && <VerifiedBadgeIcon />}
             </span>
-          </Link>
+          </ChannelRouteLink>
         ) : (
           <div className="flex items-center gap-1.5 mt-0.5">
             <ChannelAvatar

--- a/apps/web/src/components/shorts-actions.tsx
+++ b/apps/web/src/components/shorts-actions.tsx
@@ -3,6 +3,7 @@ import { useAuth } from "../hooks/use-auth";
 import { useFavoritesPlaylist } from "../hooks/use-favorites-playlist";
 import { useShareUrl } from "../hooks/use-share-url";
 import { useWatchLaterPlaylist } from "../hooks/use-watch-later-playlist";
+import { toPublicWatchUrl } from "../lib/watch-url";
 import type { VideoStream } from "../types/stream";
 import { ShortsActionButton } from "./shorts-action-button";
 
@@ -68,8 +69,7 @@ export function ShortsActions({ stream, onOpenComments, className, compact }: Pr
   }
 
   function handleShare() {
-    const watchUrl = `${window.location.origin}/watch?v=${encodeURIComponent(stream.id)}`;
-    void share(watchUrl);
+    void share(toPublicWatchUrl(stream.id, window.location.origin));
   }
 
   return (

--- a/apps/web/src/components/shorts-info-overlay.tsx
+++ b/apps/web/src/components/shorts-info-overlay.tsx
@@ -1,9 +1,9 @@
-import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { useAuth } from "../hooks/use-auth";
 import { useSubscriptions } from "../hooks/use-subscriptions";
 import type { VideoStream } from "../types/stream";
 import { ChannelAvatar } from "./channel-avatar";
+import { ChannelRouteLink } from "./channel-route-link";
 import { Toast } from "./toast";
 
 type Props = {
@@ -145,12 +145,8 @@ type ChannelLinkProps = {
 function ChannelLink({ url, children }: ChannelLinkProps) {
   if (!url) return <>{children}</>;
   return (
-    <Link
-      to="/channel"
-      search={{ url }}
-      className="pointer-events-auto hover:opacity-80 transition-opacity"
-    >
+    <ChannelRouteLink url={url} className="pointer-events-auto hover:opacity-80 transition-opacity">
       {children}
-    </Link>
+    </ChannelRouteLink>
   );
 }

--- a/apps/web/src/components/video-card.tsx
+++ b/apps/web/src/components/video-card.tsx
@@ -5,17 +5,15 @@ import { useClientLocale } from "../hooks/use-client-locale";
 import { isMemberOnlyApiError, streamQueryOptions } from "../hooks/use-stream";
 import { useWatchPrefetch } from "../hooks/use-watch-prefetch";
 import { formatDuration, formatPublishedDate, formatViews } from "../lib/format";
+import { watchRouteSearch } from "../lib/watch-url";
 import type { VideoStream } from "../types/stream";
 import { ChannelAvatar } from "./channel-avatar";
+import { ChannelRouteLink } from "./channel-route-link";
 import { VideoCardFeedbackMenu } from "./video-card-feedback-menu";
 import { VideoPreview } from "./video-preview";
 import { VerifiedBadgeIcon } from "./watch-icons";
 
-type Props = {
-  stream: VideoStream;
-  onOpen?: () => void;
-  onImpression?: () => void;
-};
+type Props = { stream: VideoStream; onOpen?: () => void; onImpression?: () => void };
 
 export function VideoCard({ stream, onOpen, onImpression }: Props) {
   const locale = useClientLocale();
@@ -93,7 +91,7 @@ export function VideoCard({ stream, onOpen, onImpression }: Props) {
     >
       <Link
         to="/watch"
-        search={{ v: stream.id }}
+        search={watchRouteSearch(stream.id)}
         className="block"
         onMouseDown={onOpen}
         onTouchStart={onOpen}
@@ -122,20 +120,20 @@ export function VideoCard({ stream, onOpen, onImpression }: Props) {
       </Link>
       <div className="flex gap-2 px-1 sm:px-0">
         {stream.channelUrl ? (
-          <Link to="/channel" search={{ url: stream.channelUrl }} className="flex-shrink-0 mt-0.5">
+          <ChannelRouteLink url={stream.channelUrl} className="flex-shrink-0 mt-0.5">
             <ChannelAvatar
               src={stream.channelAvatar}
               name={stream.channelName}
               className="w-8 h-8"
             />
-          </Link>
+          </ChannelRouteLink>
         ) : (
           <ChannelAvatar src={stream.channelAvatar} name={stream.channelName} className="w-8 h-8" />
         )}
         <div className="flex flex-col gap-0.5 min-w-0">
           <Link
             to="/watch"
-            search={{ v: stream.id }}
+            search={watchRouteSearch(stream.id)}
             className="text-sm font-medium text-fg line-clamp-2 leading-snug hover:text-white"
             onMouseDown={onOpen}
             onTouchStart={onOpen}
@@ -144,14 +142,13 @@ export function VideoCard({ stream, onOpen, onImpression }: Props) {
             {stream.title}
           </Link>
           {stream.channelUrl ? (
-            <Link
-              to="/channel"
-              search={{ url: stream.channelUrl }}
+            <ChannelRouteLink
+              url={stream.channelUrl}
               className="text-xs text-fg-muted hover:text-fg transition-colors w-fit flex items-center gap-1"
             >
               {stream.channelName}
               {stream.uploaderVerified && <VerifiedBadgeIcon />}
-            </Link>
+            </ChannelRouteLink>
           ) : (
             <p className="text-xs text-fg-muted flex items-center gap-1">
               {stream.channelName}

--- a/apps/web/src/components/watch-actions.tsx
+++ b/apps/web/src/components/watch-actions.tsx
@@ -4,6 +4,7 @@ import { useFavoritesPlaylist } from "../hooks/use-favorites-playlist";
 import { useShareUrl } from "../hooks/use-share-url";
 import { detectProvider } from "../lib/provider";
 import { goto } from "../lib/route-redirect";
+import { toPublicWatchUrl } from "../lib/watch-url";
 import type { VideoStream } from "../types/stream";
 import { DanmakuControls } from "./danmaku-controls";
 import { DownloadSheet } from "./download-sheet";
@@ -80,7 +81,7 @@ export function WatchActions({ stream }: Props) {
         <DownloadIcon />
         Download
       </WatchActionButton>
-      <WatchActionButton onClick={() => share(window.location.href)}>
+      <WatchActionButton onClick={() => share(toPublicWatchUrl(stream.id, window.location.origin))}>
         <ShareIcon />
         Share
       </WatchActionButton>

--- a/apps/web/src/components/watch-info.tsx
+++ b/apps/web/src/components/watch-info.tsx
@@ -1,10 +1,10 @@
-import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { useClientLocale } from "../hooks/use-client-locale";
 import { useSubscriptions } from "../hooks/use-subscriptions";
 import { formatPublishedDate, formatSubscribers, formatViews } from "../lib/format";
 import type { VideoStream } from "../types/stream";
 import { ChannelAvatar } from "./channel-avatar";
+import { ChannelRouteLink } from "./channel-route-link";
 import { Toast } from "./toast";
 import { VerifiedBadgeIcon } from "./watch-icons";
 
@@ -68,9 +68,8 @@ export function WatchInfo({ stream }: Props) {
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-3 min-w-0">
           {stream.channelUrl ? (
-            <Link
-              to="/channel"
-              search={{ url: stream.channelUrl }}
+            <ChannelRouteLink
+              url={stream.channelUrl}
               className="flex items-center gap-3 min-w-0 group"
             >
               <ChannelAvatar
@@ -88,7 +87,7 @@ export function WatchInfo({ stream }: Props) {
                   {publishedText && ` · ${publishedText}`}
                 </p>
               </div>
-            </Link>
+            </ChannelRouteLink>
           ) : (
             <div className="flex items-center gap-3 min-w-0">
               <ChannelAvatar

--- a/apps/web/src/hooks/use-document-title.ts
+++ b/apps/web/src/hooks/use-document-title.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+const DEFAULT_DOCUMENT_TITLE = "TypeType";
+
+function toDocumentTitle(title: string | null | undefined): string {
+  const trimmed = title?.trim();
+  return trimmed ? `${trimmed} - ${DEFAULT_DOCUMENT_TITLE}` : DEFAULT_DOCUMENT_TITLE;
+}
+
+export function useDocumentTitle(title: string | null | undefined): void {
+  useEffect(() => {
+    document.title = toDocumentTitle(title);
+    return () => {
+      document.title = DEFAULT_DOCUMENT_TITLE;
+    };
+  }, [title]);
+}

--- a/apps/web/src/lib/channel-route-url.ts
+++ b/apps/web/src/lib/channel-route-url.ts
@@ -1,0 +1,67 @@
+import type { ChannelSort } from "./api";
+
+const YOUTUBE_CHANNEL_ID_PATTERN = /^UC[A-Za-z0-9_-]{22}$/;
+const YOUTUBE_HANDLE_PATTERN = /^@[A-Za-z0-9._-]{2,48}$/;
+
+export type ChannelPathSearch = {
+  sort?: ChannelSort;
+  q?: string;
+};
+
+export type ChannelLegacySearch = ChannelPathSearch & {
+  url: string;
+};
+
+function hostMatches(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+function youtubeChannelParamFromUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (!hostMatches(parsed.hostname.toLowerCase(), "youtube.com")) return null;
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    const [kind, valueSegment] = segments;
+    if (kind === "channel" && valueSegment && YOUTUBE_CHANNEL_ID_PATTERN.test(valueSegment)) {
+      return valueSegment;
+    }
+    if (kind && YOUTUBE_HANDLE_PATTERN.test(kind)) return kind;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function toChannelSourceUrl(value: string): string {
+  const trimmed = value.trim();
+  if (YOUTUBE_CHANNEL_ID_PATTERN.test(trimmed)) return `https://www.youtube.com/channel/${trimmed}`;
+  if (YOUTUBE_HANDLE_PATTERN.test(trimmed)) return `https://www.youtube.com/${trimmed}`;
+  return trimmed;
+}
+
+function toPublicChannelParam(sourceUrl: string): string {
+  return youtubeChannelParamFromUrl(sourceUrl) ?? sourceUrl.trim();
+}
+
+export function toChannelPathParam(sourceUrl: string): string | null {
+  const publicParam = toPublicChannelParam(sourceUrl);
+  return YOUTUBE_CHANNEL_ID_PATTERN.test(publicParam) || YOUTUBE_HANDLE_PATTERN.test(publicParam)
+    ? publicParam
+    : null;
+}
+
+export function channelPathSearch(sort: ChannelSort, query: string): ChannelPathSearch {
+  const trimmedQuery = query.trim();
+  const search: ChannelPathSearch = {};
+  if (sort !== "latest") search.sort = sort;
+  if (trimmedQuery.length > 0) search.q = trimmedQuery;
+  return search;
+}
+
+export function channelLegacySearch(
+  sourceUrl: string,
+  sort: ChannelSort,
+  query: string,
+): ChannelLegacySearch {
+  return { url: toPublicChannelParam(sourceUrl), ...channelPathSearch(sort, query) };
+}

--- a/apps/web/src/lib/watch-url.ts
+++ b/apps/web/src/lib/watch-url.ts
@@ -1,0 +1,51 @@
+const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+type WatchRouteSearch = {
+  v: string;
+};
+
+function hostMatches(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+function youtubeIdFromPath(pathname: string): string | null {
+  const segments = pathname.split("/").filter(Boolean);
+  const candidate = segments[0] === "shorts" || segments[0] === "embed" ? segments[1] : segments[0];
+  return candidate && YOUTUBE_VIDEO_ID_PATTERN.test(candidate) ? candidate : null;
+}
+
+function youtubeVideoIdFromUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    const host = parsed.hostname.toLowerCase();
+    if (host === "youtu.be") return youtubeIdFromPath(parsed.pathname);
+    if (!hostMatches(host, "youtube.com")) return null;
+    const watchId = parsed.searchParams.get("v");
+    if (watchId && YOUTUBE_VIDEO_ID_PATTERN.test(watchId)) return watchId;
+    return youtubeIdFromPath(parsed.pathname);
+  } catch {
+    return null;
+  }
+}
+
+export function toWatchSourceUrl(value: string): string {
+  const trimmed = value.trim();
+  if (YOUTUBE_VIDEO_ID_PATTERN.test(trimmed)) {
+    return `https://www.youtube.com/watch?v=${trimmed}`;
+  }
+  return trimmed;
+}
+
+export function toPublicWatchParam(sourceUrl: string): string {
+  return youtubeVideoIdFromUrl(sourceUrl) ?? sourceUrl.trim();
+}
+
+export function watchRouteSearch(sourceUrl: string): WatchRouteSearch {
+  return { v: toPublicWatchParam(sourceUrl) };
+}
+
+export function toPublicWatchUrl(sourceUrl: string, origin: string): string {
+  const url = new URL("/watch", origin);
+  url.searchParams.set("v", toPublicWatchParam(sourceUrl));
+  return url.toString();
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as ImportIndexRouteImport } from './routes/import/index'
 import { Route as PlaylistsIdRouteImport } from './routes/playlists_.$id'
 import { Route as ImportYoutubeRouteImport } from './routes/import/youtube'
 import { Route as ImportPipepipeRouteImport } from './routes/import/pipepipe'
+import { Route as ChannelChannelIdRouteImport } from './routes/channel_.$channelId'
 
 const WatchLaterRoute = WatchLaterRouteImport.update({
   id: '/watch-later',
@@ -148,6 +149,11 @@ const ImportPipepipeRoute = ImportPipepipeRouteImport.update({
   path: '/pipepipe',
   getParentRoute: () => ImportRoute,
 } as any)
+const ChannelChannelIdRoute = ChannelChannelIdRouteImport.update({
+  id: '/channel_/$channelId',
+  path: '/channel/$channelId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -169,6 +175,7 @@ export interface FileRoutesByFullPath {
   '/subscriptions': typeof SubscriptionsRoute
   '/watch': typeof WatchRoute
   '/watch-later': typeof WatchLaterRoute
+  '/channel/$channelId': typeof ChannelChannelIdRoute
   '/import/pipepipe': typeof ImportPipepipeRoute
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists/$id': typeof PlaylistsIdRoute
@@ -193,6 +200,7 @@ export interface FileRoutesByTo {
   '/subscriptions': typeof SubscriptionsRoute
   '/watch': typeof WatchRoute
   '/watch-later': typeof WatchLaterRoute
+  '/channel/$channelId': typeof ChannelChannelIdRoute
   '/import/pipepipe': typeof ImportPipepipeRoute
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists/$id': typeof PlaylistsIdRoute
@@ -219,6 +227,7 @@ export interface FileRoutesById {
   '/subscriptions': typeof SubscriptionsRoute
   '/watch': typeof WatchRoute
   '/watch-later': typeof WatchLaterRoute
+  '/channel_/$channelId': typeof ChannelChannelIdRoute
   '/import/pipepipe': typeof ImportPipepipeRoute
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists_/$id': typeof PlaylistsIdRoute
@@ -246,6 +255,7 @@ export interface FileRouteTypes {
     | '/subscriptions'
     | '/watch'
     | '/watch-later'
+    | '/channel/$channelId'
     | '/import/pipepipe'
     | '/import/youtube'
     | '/playlists/$id'
@@ -270,6 +280,7 @@ export interface FileRouteTypes {
     | '/subscriptions'
     | '/watch'
     | '/watch-later'
+    | '/channel/$channelId'
     | '/import/pipepipe'
     | '/import/youtube'
     | '/playlists/$id'
@@ -295,6 +306,7 @@ export interface FileRouteTypes {
     | '/subscriptions'
     | '/watch'
     | '/watch-later'
+    | '/channel_/$channelId'
     | '/import/pipepipe'
     | '/import/youtube'
     | '/playlists_/$id'
@@ -321,6 +333,7 @@ export interface RootRouteChildren {
   SubscriptionsRoute: typeof SubscriptionsRoute
   WatchRoute: typeof WatchRoute
   WatchLaterRoute: typeof WatchLaterRoute
+  ChannelChannelIdRoute: typeof ChannelChannelIdRoute
   PlaylistsIdRoute: typeof PlaylistsIdRoute
 }
 
@@ -487,6 +500,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ImportPipepipeRouteImport
       parentRoute: typeof ImportRoute
     }
+    '/channel_/$channelId': {
+      id: '/channel_/$channelId'
+      path: '/channel/$channelId'
+      fullPath: '/channel/$channelId'
+      preLoaderRoute: typeof ChannelChannelIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -525,6 +545,7 @@ const rootRouteChildren: RootRouteChildren = {
   SubscriptionsRoute: SubscriptionsRoute,
   WatchRoute: WatchRoute,
   WatchLaterRoute: WatchLaterRoute,
+  ChannelChannelIdRoute: ChannelChannelIdRoute,
   PlaylistsIdRoute: PlaylistsIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routes/channel.tsx
+++ b/apps/web/src/routes/channel.tsx
@@ -1,163 +1,60 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { ChannelAvatar } from "../components/channel-avatar";
-import { ChannelFilterBar } from "../components/channel-filter-bar";
-import { ChannelPodcastsSection } from "../components/channel-podcasts-section";
+import { useEffect } from "react";
+import { ChannelPageContent } from "../components/channel-page-content";
 import { PageSpinner } from "../components/page-spinner";
-import { ScrollSentinel } from "../components/scroll-sentinel";
-import { VideoCard } from "../components/video-card";
-import { VideoGridSkeleton } from "../components/video-grid-skeleton";
-import { VerifiedBadgeIcon } from "../components/watch-icons";
-import { useBlockedFilter } from "../hooks/use-blocked-filter";
-import { useChannel } from "../hooks/use-channel";
-import { useSubscriptions } from "../hooks/use-subscriptions";
-import { ApiError, type ChannelSort } from "../lib/api";
+import type { ChannelSort } from "../lib/api";
+import {
+  channelLegacySearch,
+  channelPathSearch,
+  toChannelPathParam,
+  toChannelSourceUrl,
+} from "../lib/channel-route-url";
 import { splitChannelSearchUrl } from "../lib/channel-search-url";
 import { channelSortOrDefault } from "../lib/channel-sort";
-import { formatViews } from "../lib/format";
-import { detectProvider } from "../lib/provider";
 
 type ChannelRouteSearch = { url: string; sort?: ChannelSort; q?: string };
 
-function channelRouteSearch(url: string, sort: ChannelSort, query: string): ChannelRouteSearch {
-  const q = query.trim();
-  return q.length > 0 ? { url, sort, q } : { url, sort };
-}
-
-function validateChannelSearch(search: Record<string, unknown>) {
-  const parsed = splitChannelSearchUrl(typeof search.url === "string" ? search.url : "");
+function validateChannelSearch(search: Record<string, unknown>): ChannelRouteSearch {
+  const rawUrl = typeof search.url === "string" ? search.url : "";
+  const parsed = splitChannelSearchUrl(toChannelSourceUrl(rawUrl));
+  const sort = channelSortOrDefault(search.sort);
   const query = typeof search.q === "string" ? search.q.trim() : parsed.query;
-  return channelRouteSearch(parsed.channelUrl, channelSortOrDefault(search.sort), query);
+  return channelLegacySearch(parsed.channelUrl, sort, query);
 }
 
-function ChannelPage() {
+function LegacyChannelPage() {
   const { url, sort: searchSort, q } = Route.useSearch();
   const sort = searchSort ?? "latest";
   const searchQuery = q ?? "";
+  const sourceUrl = toChannelSourceUrl(url);
+  const channelId = toChannelPathParam(sourceUrl);
   const navigate = useNavigate({ from: "/channel" });
-  const {
-    meta,
-    videos,
-    isLoading,
-    isError,
-    error,
-    refetch,
-    hasNextPage,
-    isFetching,
-    isFetchingNextPage,
-    fetchNextPage,
-  } = useChannel(url, sort, searchQuery);
-  const { add, remove, isSubscribed } = useSubscriptions();
-  const { filter } = useBlockedFilter();
 
-  const subscribed = isSubscribed(url);
-  const searchAvailable = detectProvider(url) === "youtube";
-  const visibleVideos = filter(videos);
-  const isInitialLoading = isLoading && !meta;
-  const isReplacingVideos = isFetching && !isFetchingNextPage && visibleVideos.length === 0;
+  useEffect(() => {
+    if (!channelId) return;
+    navigate({
+      to: "/channel/$channelId",
+      params: { channelId },
+      search: channelPathSearch(sort, searchQuery),
+      replace: true,
+    });
+  }, [channelId, navigate, searchQuery, sort]);
 
-  function handleSubscribe() {
-    if (!meta) return;
-    if (subscribed) {
-      remove.mutate(url);
-    } else {
-      add.mutate({ channelUrl: url, name: meta.name, avatarUrl: meta.avatarUrl });
-    }
-  }
-
-  function selectSort(nextSort: ChannelSort) {
-    navigate({ search: channelRouteSearch(url, nextSort, searchQuery), replace: true });
-  }
-
-  function searchChannel(nextQuery: string) {
-    const query = searchAvailable ? nextQuery : "";
-    navigate({ search: channelRouteSearch(url, sort, query), replace: true });
-  }
-
-  if (isInitialLoading) return <PageSpinner />;
-  if (isError) {
-    const message = error instanceof ApiError ? error.message : "Unable to load channel right now.";
-    return (
-      <div className="rounded-xl border border-border bg-surface p-6 flex flex-col gap-3 max-w-xl">
-        <p className="text-sm text-fg">{message}</p>
-        <button
-          type="button"
-          onClick={() => refetch()}
-          className="h-9 w-fit rounded-md bg-fg px-3 text-xs font-medium text-app hover:bg-white"
-        >
-          Retry
-        </button>
-      </div>
-    );
-  }
+  if (channelId) return <PageSpinner />;
 
   return (
-    <div className="flex flex-col gap-6">
-      {meta && (
-        <div className="flex flex-col gap-4">
-          {meta.bannerUrl && (
-            <img src={meta.bannerUrl} alt="" className="w-full h-32 object-cover rounded-lg" />
-          )}
-          <div className="flex items-center justify-between gap-4">
-            <div className="flex items-center gap-4">
-              <ChannelAvatar src={meta.avatarUrl} name={meta.name} className="w-14 h-14" />
-              <div className="flex flex-col">
-                <h1 className="text-lg font-semibold text-fg flex items-center gap-1.5">
-                  {meta.name}
-                  {meta.isVerified && <VerifiedBadgeIcon />}
-                </h1>
-                <p className="text-sm text-fg-soft">
-                  {formatViews(meta.subscriberCount)} subscribers
-                </p>
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={handleSubscribe}
-              aria-pressed={subscribed}
-              className={`px-4 py-1.5 text-sm font-medium rounded-full transition-colors ${
-                subscribed
-                  ? "ring-1 ring-border-strong bg-surface-strong text-fg hover:bg-surface-soft"
-                  : "bg-fg text-app hover:bg-white"
-              }`}
-            >
-              {subscribed ? "Subscribed" : "Subscribe"}
-            </button>
-          </div>
-        </div>
-      )}
-      <ChannelPodcastsSection channelUrl={url} channelAvatar={meta?.avatarUrl} />
-      <ChannelFilterBar
-        sort={sort}
-        query={searchQuery}
-        searchAvailable={searchAvailable}
-        onSearch={searchChannel}
-        onSortChange={selectSort}
-      />
-      {isReplacingVideos ? (
-        <VideoGridSkeleton idPrefix="channel-replace" />
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-4 gap-y-8">
-          {visibleVideos.map((v, index) => (
-            <div
-              key={v.id}
-              className="animate-card-pop-in"
-              style={{ animationDelay: `${Math.min(index * 45, 270)}ms` }}
-            >
-              <VideoCard stream={v} />
-            </div>
-          ))}
-        </div>
-      )}
-      {isFetchingNextPage && <VideoGridSkeleton idPrefix="channel-next" />}
-      <ScrollSentinel
-        onIntersect={fetchNextPage}
-        enabled={hasNextPage && !isFetchingNextPage && !isReplacingVideos}
-      />
-    </div>
+    <ChannelPageContent
+      sourceUrl={sourceUrl}
+      sort={sort}
+      searchQuery={searchQuery}
+      onNavigate={(nextSort, nextQuery) =>
+        navigate({ search: channelLegacySearch(sourceUrl, nextSort, nextQuery), replace: true })
+      }
+    />
   );
 }
 
 export const Route = createFileRoute("/channel")({
   validateSearch: validateChannelSearch,
-  component: ChannelPage,
+  component: LegacyChannelPage,
 });

--- a/apps/web/src/routes/channel_.$channelId.tsx
+++ b/apps/web/src/routes/channel_.$channelId.tsx
@@ -1,0 +1,38 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { ChannelPageContent } from "../components/channel-page-content";
+import type { ChannelSort } from "../lib/api";
+import { channelPathSearch, toChannelSourceUrl } from "../lib/channel-route-url";
+import { channelSortOrDefault } from "../lib/channel-sort";
+
+type ChannelPathRouteSearch = { sort?: ChannelSort; q?: string };
+
+function validateChannelPathSearch(search: Record<string, unknown>): ChannelPathRouteSearch {
+  const sort = channelSortOrDefault(search.sort);
+  const query = typeof search.q === "string" ? search.q.trim() : "";
+  return channelPathSearch(sort, query);
+}
+
+function ChannelPathPage() {
+  const { channelId } = Route.useParams();
+  const { sort: searchSort, q } = Route.useSearch();
+  const sort = searchSort ?? "latest";
+  const searchQuery = q ?? "";
+  const sourceUrl = toChannelSourceUrl(channelId);
+  const navigate = useNavigate({ from: "/channel/$channelId" });
+
+  return (
+    <ChannelPageContent
+      sourceUrl={sourceUrl}
+      sort={sort}
+      searchQuery={searchQuery}
+      onNavigate={(nextSort, nextQuery) =>
+        navigate({ search: channelPathSearch(nextSort, nextQuery), replace: true })
+      }
+    />
+  );
+}
+
+export const Route = createFileRoute("/channel_/$channelId")({
+  validateSearch: validateChannelPathSearch,
+  component: ChannelPathPage,
+});

--- a/apps/web/src/routes/watch.tsx
+++ b/apps/web/src/routes/watch.tsx
@@ -1,8 +1,9 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { lazy, Suspense, useEffect, useRef } from "react";
 import { PageSpinner } from "../components/page-spinner";
 import { StreamError } from "../components/stream-error";
 import { useAuth } from "../hooks/use-auth";
+import { useDocumentTitle } from "../hooks/use-document-title";
 import { useHistory } from "../hooks/use-history";
 import { useProgress } from "../hooks/use-progress";
 import {
@@ -12,6 +13,7 @@ import {
   useStream,
 } from "../hooks/use-stream";
 import { ApiError } from "../lib/api";
+import { toPublicWatchParam, toWatchSourceUrl } from "../lib/watch-url";
 
 const WatchLayout = lazy(() =>
   import("../components/watch-layout").then((module) => ({ default: module.WatchLayout })),
@@ -32,14 +34,24 @@ function PlayerOnlyLoader() {
 
 function WatchPage() {
   const { v } = Route.useSearch();
+  const navigate = useNavigate({ from: "/watch" });
+  const sourceUrl = toWatchSourceUrl(v);
+  const publicParam = toPublicWatchParam(sourceUrl);
   const { authReady, isAuthed } = useAuth();
-  const { data: stream, isLoading, isError, error, refetch } = useStream(v);
+  const { data: stream, isLoading, isError, error, refetch } = useStream(sourceUrl);
   const { add } = useHistory();
-  const progressFetch = useProgress(v);
+  const progressFetch = useProgress(sourceUrl);
+  useDocumentTitle(stream?.title);
 
   const addToHistoryRef = useRef(add.mutate);
   addToHistoryRef.current = add.mutate;
   const historyAddedForRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (v.trim() && publicParam !== v.trim()) {
+      navigate({ search: { v: publicParam }, replace: true });
+    }
+  }, [navigate, publicParam, v]);
 
   useEffect(() => {
     if (!stream) return;
@@ -106,7 +118,7 @@ function WatchPage() {
 
 export const Route = createFileRoute("/watch")({
   validateSearch: (search: Record<string, unknown>) => ({
-    v: typeof search.v === "string" ? search.v : "",
+    v: typeof search.v === "string" ? search.v.trim() : "",
   }),
   component: WatchPage,
 });


### PR DESCRIPTION
## Summary
- expose YouTube watch pages as clean /watch?v=<id> URLs while keeping backend requests on source URLs
- expose YouTube channels as /channel/<id-or-handle>, preserving sort and channel search in query params
- canonicalize legacy encoded watch/channel URLs and set watch/channel document titles from loaded data

Closes https://github.com/Priveetee/TypeType/issues/50
Closes https://github.com/Priveetee/TypeType/issues/51

## Verification
- bun run check
- bun run build
- bun run knip
- bun run sherif
- git diff --check
- headless Playwright smoke for clean watch URL, Share URL, legacy watch redirect, channel path, sort, channel search, and legacy channel redirect