### PR TITLE
fix: upgrade frontend openssl packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN bun run --cwd apps/web build
 
 FROM nginx:1.31.0-alpine AS runner
 
-RUN apk upgrade --no-cache libxml2
+RUN apk upgrade --no-cache libxml2 libcrypto3 libssl3
 
 COPY --from=builder /app/apps/web/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- upgrade Alpine libcrypto3 and libssl3 in the frontend runtime image
- keep the existing libxml2 runtime upgrade

## Verification
- docker build -t typetype-frontend:openssl-fix-local .
- trivy image --cache-dir /tmp/opencode/trivy-typetype-cache --severity HIGH,CRITICAL --exit-code 1 typetype-frontend:openssl-fix-local
- git diff --check