### PR TITLE
fix: handle downloader storage exhaustion

### DIFF
--- a/apps/web/src/components/downloader-job-feedback.tsx
+++ b/apps/web/src/components/downloader-job-feedback.tsx
@@ -8,11 +8,13 @@ import {
   isFailedDownloaderJob,
   shouldShowDownloaderProgress,
 } from "../lib/downloader-display";
+import { DOWNLOADER_INSUFFICIENT_STORAGE_CODE } from "../lib/downloader-errors";
 import type {
   DownloaderJobStage,
   DownloaderJobStatus,
   DownloaderResolvedSelection,
 } from "../types/downloader";
+import { DownloaderStorageError } from "./downloader-storage-error";
 
 type Props = {
   status: DownloaderJobStatus | null;
@@ -79,6 +81,7 @@ export function DownloaderJobFeedback({
   const failed = isFailedDownloaderJob(status, stage, errorCode);
   const label = downloaderStatusLabel(status, stage, errorCode, forceWaiting);
   const message = downloaderStatusMessage(status, stage, errorCode, visibleError, forceWaiting);
+  const insufficientStorage = errorCode === DOWNLOADER_INSUFFICIENT_STORAGE_CODE;
   const progress = downloaderProgressValue(status, stage, progressPercent, forceWaiting);
   const activeStep = downloaderStageIndex(status, stage);
   const showCancel = canCancel && !cancelled && !failed && typeof onCancel === "function";
@@ -127,6 +130,7 @@ export function DownloaderJobFeedback({
           )}
         </div>
       </div>
+      {insufficientStorage && <DownloaderStorageError />}
       {showProgress && (
         <div className="mt-3 h-2 overflow-hidden rounded-full bg-app">
           <div

--- a/apps/web/src/components/downloader-storage-error.tsx
+++ b/apps/web/src/components/downloader-storage-error.tsx
@@ -1,0 +1,16 @@
+import { DOWNLOADER_INSUFFICIENT_STORAGE_HELP } from "../lib/downloader-errors";
+
+export function DownloaderStorageError() {
+  return (
+    <div className="mt-3 flex items-center gap-3 rounded-xl border border-danger/20 bg-app/60 p-2">
+      <img
+        src="/downloader-waiting.gif"
+        alt=""
+        className="h-20 w-20 rounded-xl object-cover motion-reduce:hidden"
+      />
+      <p className="text-xs leading-relaxed text-fg-muted">
+        {DOWNLOADER_INSUFFICIENT_STORAGE_HELP}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-downloader-job.ts
+++ b/apps/web/src/hooks/use-downloader-job.ts
@@ -7,6 +7,7 @@ import {
   downloadDownloaderArtifact,
   fetchDownloaderJob,
 } from "../lib/api-downloader";
+import { downloaderErrorCode } from "../lib/downloader-errors";
 import { subscribeDownloaderEvents } from "../lib/downloader-events";
 import type {
   DownloaderCreateJobRequest,
@@ -23,6 +24,7 @@ export function useDownloaderJob() {
 
   const create = useMutation({
     mutationFn: (payload: DownloaderCreateJobRequest) => createDownloaderJob(payload),
+    retry: false,
   });
   const jobId = create.data?.id;
   const cancel = useMutation({
@@ -83,25 +85,29 @@ export function useDownloaderJob() {
     };
   }, [create.data, eventJob, query.data]);
 
-  const status: DownloaderJobStatus | null = create.isPending ? "queued" : (job?.status ?? null);
+  const createError = create.error instanceof Error ? create.error : null;
+  const status: DownloaderJobStatus | null = create.isPending
+    ? "queued"
+    : createError
+      ? "failed"
+      : (job?.status ?? null);
   const isQueued = status === "queued";
   const isRunning = status === "running";
   const isDone = status === "done";
   const isFailed = status === "failed";
-  const stage: DownloaderJobStage | null = job?.stage ?? null;
+  const stage: DownloaderJobStage | null = createError ? "failed" : (job?.stage ?? null);
   const progressPercent = typeof job?.progressPercent === "number" ? job.progressPercent : null;
   const resolved = job?.resolved ?? null;
-  const errorCode = job?.errorCode ?? null;
+  const errorCode = downloaderErrorCode(createError) ?? job?.errorCode ?? null;
   const tokenFetchMs = typeof job?.tokenFetchMs === "number" ? job.tokenFetchMs : null;
   const ytdlpMs = typeof job?.ytdlpMs === "number" ? job.ytdlpMs : null;
   const uploadMs = typeof job?.uploadMs === "number" ? job.uploadMs : null;
   const totalMs = typeof job?.totalMs === "number" ? job.totalMs : null;
-  const errorText =
-    create.error instanceof Error
-      ? create.error.message
-      : cancel.error instanceof Error
-        ? cancel.error.message
-        : job?.error || (query.error instanceof Error ? query.error.message : null);
+  const errorText = createError
+    ? createError.message
+    : cancel.error instanceof Error
+      ? cancel.error.message
+      : job?.error || (query.error instanceof Error ? query.error.message : null);
 
   function start(payload: DownloaderCreateJobRequest) {
     setEventJob(null);

--- a/apps/web/src/lib/api-downloader.ts
+++ b/apps/web/src/lib/api-downloader.ts
@@ -4,13 +4,14 @@ import type {
   DownloaderJobResponse,
 } from "../types/downloader";
 import { ApiError } from "./api";
+import {
+  DOWNLOADER_INSUFFICIENT_STORAGE_CODE,
+  DOWNLOADER_INSUFFICIENT_STORAGE_MESSAGE,
+  DownloaderApiError,
+  normalizeDownloaderErrorCode,
+} from "./downloader-errors";
 import { API_BASE as BASE } from "./env";
 import { isIosWebKitBrowser } from "./ios-device";
-
-type ErrorBody = {
-  error?: string;
-  message?: string;
-};
 
 type DownloadArtifactOptions = {
   preferShare?: boolean;
@@ -23,14 +24,26 @@ async function readJson(res: Response): Promise<unknown> {
   return res.json().catch(() => ({}));
 }
 
+function readStringField(body: unknown, field: "code" | "error" | "message"): string | null {
+  if (!body || typeof body !== "object") return null;
+  let value: unknown;
+  if (field === "code" && "code" in body) value = body.code;
+  if (field === "error" && "error" in body) value = body.error;
+  if (field === "message" && "message" in body) value = body.message;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 function readErrorMessage(body: unknown, fallback: string): string {
-  if (body && typeof body === "object") {
-    const candidate = body as ErrorBody;
-    if (typeof candidate.error === "string" && candidate.error.length > 0) return candidate.error;
-    if (typeof candidate.message === "string" && candidate.message.length > 0)
-      return candidate.message;
-  }
-  return fallback;
+  return readStringField(body, "error") ?? readStringField(body, "message") ?? fallback;
+}
+
+function readDownloaderError(body: unknown, status: number, fallback: string): DownloaderApiError {
+  const code = normalizeDownloaderErrorCode(status, readStringField(body, "code"));
+  const message =
+    code === DOWNLOADER_INSUFFICIENT_STORAGE_CODE
+      ? DOWNLOADER_INSUFFICIENT_STORAGE_MESSAGE
+      : readErrorMessage(body, fallback);
+  return new DownloaderApiError(message, status, code);
 }
 
 function delay(ms: number): Promise<void> {
@@ -47,7 +60,7 @@ export async function createDownloaderJob(
   });
   const body = await readJson(res);
   if (!res.ok) {
-    throw new ApiError(readErrorMessage(body, "Failed to create download job"), res.status);
+    throw readDownloaderError(body, res.status, "Failed to create download job");
   }
   return body as DownloaderCreateJobResponse;
 }

--- a/apps/web/src/lib/downloader-errors.ts
+++ b/apps/web/src/lib/downloader-errors.ts
@@ -1,0 +1,28 @@
+import { ApiError } from "./api";
+
+export const DOWNLOADER_INSUFFICIENT_STORAGE_CODE = "insufficient_storage";
+export const DOWNLOADER_INSUFFICIENT_STORAGE_MESSAGE =
+  "Stockage temporairement sature, reessayez plus tard.";
+export const DOWNLOADER_INSUFFICIENT_STORAGE_HELP =
+  "Si le probleme persiste, contactez l'administrateur de l'instance avec le code : insufficient_storage (HTTP 507).";
+
+export class DownloaderApiError extends ApiError {
+  code: string | null;
+
+  constructor(message: string, status: number, code: string | null) {
+    super(message, status);
+    this.name = "DownloaderApiError";
+    this.code = code;
+  }
+}
+
+export function normalizeDownloaderErrorCode(status: number, code: string | null): string | null {
+  if (status === 507 || code === DOWNLOADER_INSUFFICIENT_STORAGE_CODE) {
+    return DOWNLOADER_INSUFFICIENT_STORAGE_CODE;
+  }
+  return code;
+}
+
+export function downloaderErrorCode(error: Error | null): string | null {
+  return error instanceof DownloaderApiError ? error.code : null;
+}


### PR DESCRIPTION
## Summary
- detect downloader `507` / `insufficient_storage` responses and keep the controlled backend message
- stop retrying downloader job creation on controlled storage failures
- show admin guidance and the waiting GIF only for `insufficient_storage`

## Verification
- quality checks passed
- production build passed
- downloader `507` scenario passed
- LAN manual validation passed