### PR TITLE
feat: add player and content controls

### DIFF
--- a/apps/web/src/components/player-fast-forward-indicator.tsx
+++ b/apps/web/src/components/player-fast-forward-indicator.tsx
@@ -1,0 +1,10 @@
+import { Rabbit } from "lucide-react";
+
+export function PlayerFastForwardIndicator() {
+  return (
+    <div className="pointer-events-none absolute bottom-18 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 rounded-full bg-black/70 px-3.5 py-2 text-sm font-semibold text-white shadow-lg ring-1 ring-white/20 backdrop-blur-sm sm:bottom-24 sm:px-4 sm:text-base">
+      <Rabbit className="player-rabbit-hop h-5 w-5" aria-hidden="true" />
+      <span>2x</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/player-hotkeys-utils.ts
+++ b/apps/web/src/components/player-hotkeys-utils.ts
@@ -23,6 +23,7 @@ export function consumePointerEvent(event: PointerEvent) {
   event.stopImmediatePropagation();
 }
 
-export function isMobilePointer(event: PointerEvent): boolean {
+export function isFastForwardPointer(event: PointerEvent): boolean {
+  if (event.pointerType === "mouse") return event.button === 0;
   return event.pointerType === "touch" || event.pointerType === "pen";
 }

--- a/apps/web/src/components/player-hotkeys-utils.ts
+++ b/apps/web/src/components/player-hotkeys-utils.ts
@@ -1,0 +1,28 @@
+export function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return Boolean(
+    target.closest(
+      "a, button, input, textarea, select, summary, [contenteditable='true'], [role='button'], [role='menuitem'], [role='slider']",
+    ),
+  );
+}
+
+export function clampTime(value: number, duration: number): number {
+  const max = duration > 0 ? duration : Number.POSITIVE_INFINITY;
+  return Math.min(max, Math.max(0, value));
+}
+
+export function consumeEvent(event: KeyboardEvent) {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+}
+
+export function consumePointerEvent(event: PointerEvent) {
+  event.preventDefault();
+  event.stopImmediatePropagation();
+}
+
+export function isMobilePointer(event: PointerEvent): boolean {
+  return event.pointerType === "touch" || event.pointerType === "pen";
+}

--- a/apps/web/src/components/player-hotkeys.tsx
+++ b/apps/web/src/components/player-hotkeys.tsx
@@ -5,8 +5,8 @@ import {
   clampTime,
   consumeEvent,
   consumePointerEvent,
+  isFastForwardPointer,
   isInteractiveTarget,
-  isMobilePointer,
 } from "./player-hotkeys-utils";
 
 const HOLD_SPEED = 2;
@@ -127,7 +127,7 @@ export function PlayerHotkeys({ canSeek }: { canSeek: boolean }) {
     }
 
     function onPointerDown(event: PointerEvent) {
-      if (!isMobilePointer(event)) return;
+      if (!isFastForwardPointer(event)) return;
       if (event.defaultPrevented || isInteractiveTarget(event.target)) return;
       if (touchPointerIdRef.current !== null) return;
       touchPointerIdRef.current = event.pointerId;

--- a/apps/web/src/components/player-hotkeys.tsx
+++ b/apps/web/src/components/player-hotkeys.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useRef, useState } from "react";
+import { useMediaPlayer, useMediaRemote, useMediaState } from "../lib/vidstack";
+import { PlayerFastForwardIndicator } from "./player-fast-forward-indicator";
+import {
+  clampTime,
+  consumeEvent,
+  consumePointerEvent,
+  isInteractiveTarget,
+  isMobilePointer,
+} from "./player-hotkeys-utils";
+
+const HOLD_SPEED = 2;
+const HOLD_DELAY_MS = 180;
+const FRAME_STEP_SECONDS = 1 / 30;
+
+export function PlayerHotkeys({ canSeek }: { canSeek: boolean }) {
+  const player = useMediaPlayer();
+  const remote = useMediaRemote();
+  const paused = useMediaState("paused");
+  const currentTime = useMediaState("currentTime");
+  const duration = useMediaState("duration");
+  const playbackRate = useMediaState("playbackRate");
+  const [holdingFastForward, setHoldingFastForward] = useState(false);
+  const pausedRef = useRef(true);
+  const currentTimeRef = useRef(0);
+  const durationRef = useRef(0);
+  const playbackRateRef = useRef(1);
+  const holdTimerRef = useRef<number | null>(null);
+  const holdActiveRef = useRef(false);
+  const spaceStartedRef = useRef(false);
+  const touchPointerIdRef = useRef<number | null>(null);
+  const holdStartedPausedRef = useRef(false);
+  const restoreRateRef = useRef(1);
+
+  pausedRef.current = paused;
+  currentTimeRef.current = Number.isFinite(currentTime) ? currentTime : 0;
+  durationRef.current = Number.isFinite(duration) ? duration : 0;
+  playbackRateRef.current = Number.isFinite(playbackRate) && playbackRate > 0 ? playbackRate : 1;
+
+  useEffect(() => {
+    function clearHoldTimer() {
+      if (holdTimerRef.current === null) return;
+      window.clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+
+    function restoreRate({ updateIndicator = true } = {}) {
+      clearHoldTimer();
+      if (!holdActiveRef.current) return;
+      holdActiveRef.current = false;
+      if (updateIndicator) setHoldingFastForward(false);
+      remote.changePlaybackRate(restoreRateRef.current);
+      if (holdStartedPausedRef.current) {
+        void Promise.resolve(remote.pause()).catch(() => {});
+      }
+      holdStartedPausedRef.current = false;
+    }
+
+    function startHold() {
+      if (holdTimerRef.current !== null || holdActiveRef.current) return;
+      holdTimerRef.current = window.setTimeout(() => {
+        holdTimerRef.current = null;
+        holdActiveRef.current = true;
+        setHoldingFastForward(true);
+        holdStartedPausedRef.current = pausedRef.current;
+        restoreRateRef.current = playbackRateRef.current;
+        remote.changePlaybackRate(HOLD_SPEED);
+        if (pausedRef.current) {
+          void Promise.resolve(remote.play()).catch(() => {});
+        }
+      }, HOLD_DELAY_MS);
+    }
+
+    function togglePaused() {
+      if (pausedRef.current) {
+        void Promise.resolve(remote.play()).catch(() => {});
+      } else {
+        void Promise.resolve(remote.pause()).catch(() => {});
+      }
+    }
+
+    function stepFrame(direction: -1 | 1) {
+      if (!canSeek || !pausedRef.current) return;
+      const next = clampTime(
+        currentTimeRef.current + FRAME_STEP_SECONDS * direction,
+        durationRef.current,
+      );
+      remote.seek(next);
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey) return;
+      if (isInteractiveTarget(event.target)) return;
+      if (event.code === "Space") {
+        consumeEvent(event);
+        if (!event.repeat) {
+          spaceStartedRef.current = true;
+          startHold();
+        }
+        return;
+      }
+      if (event.key === "," || event.code === "Comma") {
+        consumeEvent(event);
+        stepFrame(-1);
+        return;
+      }
+      if (event.key === "." || event.code === "Period") {
+        consumeEvent(event);
+        stepFrame(1);
+      }
+    }
+
+    function onKeyUp(event: KeyboardEvent) {
+      if (event.code !== "Space") return;
+      if (!spaceStartedRef.current) return;
+      spaceStartedRef.current = false;
+      consumeEvent(event);
+      const wasHolding = holdActiveRef.current;
+      restoreRate();
+      if (!wasHolding) togglePaused();
+    }
+
+    function onBlur() {
+      spaceStartedRef.current = false;
+      touchPointerIdRef.current = null;
+      restoreRate();
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      if (!isMobilePointer(event)) return;
+      if (event.defaultPrevented || isInteractiveTarget(event.target)) return;
+      if (touchPointerIdRef.current !== null) return;
+      touchPointerIdRef.current = event.pointerId;
+      startHold();
+    }
+
+    function onPointerEnd(event: PointerEvent) {
+      if (touchPointerIdRef.current !== event.pointerId) return;
+      touchPointerIdRef.current = null;
+      const wasHolding = holdActiveRef.current;
+      restoreRate();
+      if (wasHolding) consumePointerEvent(event);
+    }
+
+    function onContextMenu(event: MouseEvent) {
+      if (!holdActiveRef.current || isInteractiveTarget(event.target)) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+
+    const options = { capture: true };
+    const playerElement = player?.el;
+    window.addEventListener("keydown", onKeyDown, options);
+    window.addEventListener("keyup", onKeyUp, options);
+    window.addEventListener("blur", onBlur);
+    playerElement?.addEventListener("pointerdown", onPointerDown, options);
+    window.addEventListener("pointerup", onPointerEnd, options);
+    window.addEventListener("pointercancel", onPointerEnd, options);
+    window.addEventListener("contextmenu", onContextMenu, options);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, options);
+      window.removeEventListener("keyup", onKeyUp, options);
+      window.removeEventListener("blur", onBlur);
+      playerElement?.removeEventListener("pointerdown", onPointerDown, options);
+      window.removeEventListener("pointerup", onPointerEnd, options);
+      window.removeEventListener("pointercancel", onPointerEnd, options);
+      window.removeEventListener("contextmenu", onContextMenu, options);
+      restoreRate({ updateIndicator: false });
+      clearHoldTimer();
+    };
+  }, [canSeek, player, remote]);
+
+  if (!holdingFastForward) return null;
+
+  return <PlayerFastForwardIndicator />;
+}

--- a/apps/web/src/components/player-internals.tsx
+++ b/apps/web/src/components/player-internals.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { isIosDevice } from "../lib/ios-device";
+import { getSponsorBlockEndTime, getSponsorBlockStartTime } from "../lib/sponsorblock-settings";
 import { useMediaPlayer, useMediaRemote, useMediaState } from "../lib/vidstack";
 import type { SponsorBlockSegmentItem } from "../types/api";
 
@@ -44,19 +45,52 @@ export function PlayerSeeker({ startTime }: { startTime: number }) {
   return null;
 }
 
-export function SponsorBlockSkipper({ segments }: { segments: SponsorBlockSegmentItem[] }) {
+export function SponsorBlockSkipper({
+  segments,
+  muteInsteadOfSkip,
+}: {
+  segments: SponsorBlockSegmentItem[];
+  muteInsteadOfSkip: boolean;
+}) {
+  const player = useMediaPlayer();
   const remote = useMediaRemote();
   const currentTime = useMediaState("currentTime");
+  const duration = useMediaState("duration");
+  const muted = useMediaState("muted");
+  const activeMuteRef = useRef<string | null>(null);
+  const restoreMutedRef = useRef(false);
   useEffect(() => {
+    function setMuted(value: boolean) {
+      const media = player?.el?.ownerDocument.querySelector<HTMLMediaElement>("video,audio");
+      if (!media) return;
+      media.muted = value;
+      media.dispatchEvent(new Event("volumechange", { bubbles: true }));
+    }
+
+    let activeMute: string | null = null;
     for (const seg of segments) {
       if (seg.action !== "skip") continue;
-      const startSec = seg.startTime / 1000;
-      const endSec = seg.endTime / 1000;
-      if (currentTime >= startSec && currentTime < endSec) {
-        remote.seek(endSec);
+      const startTime = getSponsorBlockStartTime(seg, duration);
+      const endTime = getSponsorBlockEndTime(seg, duration);
+      if (currentTime >= startTime && currentTime < endTime) {
+        if (!muteInsteadOfSkip) {
+          remote.seek(endTime);
+          break;
+        }
+        activeMute = `${seg.category}:${seg.startTime}`;
+        if (activeMuteRef.current !== activeMute) {
+          activeMuteRef.current = activeMute;
+          restoreMutedRef.current = !muted;
+        }
+        setMuted(true);
         break;
       }
     }
-  }, [currentTime, segments, remote]);
+    if (muteInsteadOfSkip && !activeMute && activeMuteRef.current) {
+      if (restoreMutedRef.current) setMuted(false);
+      activeMuteRef.current = null;
+      restoreMutedRef.current = false;
+    }
+  }, [currentTime, duration, muted, muteInsteadOfSkip, player, segments, remote]);
   return null;
 }

--- a/apps/web/src/components/shorts-actions.tsx
+++ b/apps/web/src/components/shorts-actions.tsx
@@ -12,9 +12,16 @@ type Props = {
   onOpenComments: () => void;
   className?: string;
   compact?: boolean;
+  showComments?: boolean;
 };
 
-export function ShortsActions({ stream, onOpenComments, className, compact }: Props) {
+export function ShortsActions({
+  stream,
+  onOpenComments,
+  className,
+  compact,
+  showComments = true,
+}: Props) {
   const { isAuthed } = useAuth();
   const { copied, share } = useShareUrl();
   const {
@@ -92,12 +99,14 @@ export function ShortsActions({ stream, onOpenComments, className, compact }: Pr
         compact={compact}
         onClick={() => void toggleWatchLater()}
       />
-      <ShortsActionButton
-        icon={MessageCircle}
-        label="Comments"
-        compact={compact}
-        onClick={onOpenComments}
-      />
+      {showComments && (
+        <ShortsActionButton
+          icon={MessageCircle}
+          label="Comments"
+          compact={compact}
+          onClick={onOpenComments}
+        />
+      )}
       <ShortsActionButton
         icon={Share2}
         label="Share"

--- a/apps/web/src/components/shorts-player-shell.tsx
+++ b/apps/web/src/components/shorts-player-shell.tsx
@@ -115,6 +115,7 @@ export function ShortsPlayerShell({ targetUrl }: Props) {
       originalAudioLocale={originalAudioLocale}
       defaultSubtitleLanguage={settings.defaultSubtitleLanguage || undefined}
       subtitlesEnabled={settings.subtitlesEnabled}
+      showComments={!settings.hideComments}
       onOpenComments={() => setCommentsOpen(true)}
       onCloseComments={() => setCommentsOpen(false)}
       onRetry={() => streamQuery.refetch()}

--- a/apps/web/src/components/shorts-player-stage.tsx
+++ b/apps/web/src/components/shorts-player-stage.tsx
@@ -32,6 +32,7 @@ type Props = {
   originalAudioLocale?: string | null;
   defaultSubtitleLanguage?: string;
   subtitlesEnabled?: boolean;
+  showComments: boolean;
   onOpenComments: () => void;
   onCloseComments: () => void;
   onRetry: () => void;
@@ -67,6 +68,7 @@ export function ShortsPlayerStage({
   originalAudioLocale,
   defaultSubtitleLanguage,
   subtitlesEnabled,
+  showComments,
   onOpenComments,
   onCloseComments,
   onRetry,
@@ -148,22 +150,29 @@ export function ShortsPlayerStage({
             <ShortsActions
               stream={active}
               onOpenComments={onOpenComments}
+              showComments={showComments}
               className="absolute bottom-24 right-1.5 z-30 md:hidden"
               compact
             />
           </div>
           <div className="hidden flex-col items-center gap-3 md:flex">
-            <ShortsActions stream={active} onOpenComments={onOpenComments} />
+            <ShortsActions
+              stream={active}
+              onOpenComments={onOpenComments}
+              showComments={showComments}
+            />
             <ShortsNavigation onPrev={onPrev} onNext={onNext} hasPrev={hasPrev} hasNext={hasNext} />
           </div>
         </div>
       </div>
-      <ShortsCommentsSheetSlot
-        videoUrl={active.id}
-        anchorEl={playerRef.current}
-        open={commentsOpen}
-        onClose={onCloseComments}
-      />
+      {showComments && (
+        <ShortsCommentsSheetSlot
+          videoUrl={active.id}
+          anchorEl={playerRef.current}
+          open={commentsOpen}
+          onClose={onCloseComments}
+        />
+      )}
     </section>
   );
 }

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -67,6 +67,11 @@ export function Sidebar() {
   }
 
   const adminSearch = { section: "issues" as const };
+  const navItems = NAV_ITEMS.filter((item) => {
+    if (item.adminOnly && !isAdmin) return false;
+    if (item.to === "/shorts" && settings.hideShorts) return false;
+    return true;
+  });
 
   const baseClasses = isMobile
     ? `fixed top-14 left-0 bottom-0 z-50 w-72 max-w-[85vw] bg-app flex flex-col py-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] transition-transform duration-200 ${
@@ -96,7 +101,7 @@ export function Sidebar() {
       )}
       <aside className={baseClasses}>
         <div className={`flex flex-col gap-1 ${sectionPadding}`}>
-          {NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin).map((item) => (
+          {navItems.map((item) => (
             <Link
               key={item.label}
               to={item.to}

--- a/apps/web/src/components/sponsorblock-bar.tsx
+++ b/apps/web/src/components/sponsorblock-bar.tsx
@@ -1,18 +1,11 @@
 import { useEffect, useRef } from "react";
+import {
+  getSponsorBlockCategoryColor,
+  getSponsorBlockEndTime,
+  getSponsorBlockStartTime,
+} from "../lib/sponsorblock-settings";
 import { useMediaState } from "../lib/vidstack";
 import type { SponsorBlockSegmentItem } from "../types/api";
-
-const CATEGORY_COLORS: Record<string, string> = {
-  sponsor: "#00d400",
-  selfpromo: "#ffff00",
-  interaction: "#cc00ff",
-  poi_highlight: "#ff1684",
-  intro: "#00ffff",
-  outro: "#0202ed",
-  preview: "#008fd6",
-  filler: "#7300ff",
-  music_offtopic: "#ff9900",
-};
 
 const TRACK_HEIGHT = 5;
 const THUMB_MARGIN = 7.5;
@@ -23,10 +16,12 @@ type SegmentBarProps = {
 };
 
 function SegmentBar({ segment, duration }: SegmentBarProps) {
-  const color = CATEGORY_COLORS[segment.category];
+  const color = getSponsorBlockCategoryColor(segment.category);
   if (!color) return null;
-  const left = (segment.startTime / 1000 / duration) * 100;
-  const width = ((segment.endTime - segment.startTime) / 1000 / duration) * 100;
+  const startTime = getSponsorBlockStartTime(segment, duration);
+  const endTime = getSponsorBlockEndTime(segment, duration);
+  const left = (startTime / duration) * 100;
+  const width = ((endTime - startTime) / duration) * 100;
   return (
     <div
       style={{

--- a/apps/web/src/components/sponsorblock-current-segment.tsx
+++ b/apps/web/src/components/sponsorblock-current-segment.tsx
@@ -1,0 +1,68 @@
+import { BadgeInfo, SkipForward } from "lucide-react";
+import {
+  getSponsorBlockCategoryLabel,
+  getSponsorBlockEndTime,
+  getSponsorBlockStartTime,
+} from "../lib/sponsorblock-settings";
+import { useMediaRemote, useMediaState } from "../lib/vidstack";
+import type { SponsorBlockSegmentItem } from "../types/api";
+
+type Props = {
+  segments: SponsorBlockSegmentItem[];
+  autoSkipSegments?: SponsorBlockSegmentItem[];
+  manualSkipSegments?: SponsorBlockSegmentItem[];
+  muteInsteadOfSkip: boolean;
+};
+
+function includesSegment(
+  segments: SponsorBlockSegmentItem[] | undefined,
+  segment: SponsorBlockSegmentItem,
+) {
+  return segments?.some(
+    (item) => item.category === segment.category && item.startTime === segment.startTime,
+  );
+}
+
+export function SponsorBlockCurrentSegment({
+  segments,
+  autoSkipSegments,
+  manualSkipSegments,
+  muteInsteadOfSkip,
+}: Props) {
+  const remote = useMediaRemote();
+  const currentTime = useMediaState("currentTime");
+  const duration = useMediaState("duration");
+  const current = segments.find(
+    (segment) =>
+      currentTime >= getSponsorBlockStartTime(segment, duration) &&
+      currentTime < getSponsorBlockEndTime(segment, duration),
+  );
+
+  if (!current) return null;
+  const autoSkip = includesSegment(autoSkipSegments, current);
+  const canSkip = includesSegment(manualSkipSegments, current) || !autoSkip || muteInsteadOfSkip;
+
+  const label = getSponsorBlockCategoryLabel(current.category);
+
+  return (
+    <div className="absolute left-3 top-3 z-40 flex max-w-[calc(100%-1.5rem)] items-center gap-2 rounded-xl border border-white/15 bg-black/75 px-2.5 py-2 text-xs text-white shadow-lg backdrop-blur sm:left-auto sm:right-4 sm:top-4 sm:max-w-[min(22rem,calc(100%-2rem))] sm:rounded-full sm:px-3">
+      <BadgeInfo className="h-4 w-4 flex-shrink-0 text-white/80" aria-hidden="true" />
+      <div className="min-w-0 leading-tight">
+        <div className="truncate font-medium">{label}</div>
+        <div className="hidden text-[10px] uppercase tracking-wide text-white/55 sm:block">
+          SponsorBlock
+        </div>
+      </div>
+      {canSkip && (
+        <button
+          type="button"
+          onClick={() => remote.seek(getSponsorBlockEndTime(current, duration))}
+          className="ml-1 inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-white px-2.5 py-1 text-[11px] font-medium text-black transition-colors hover:bg-white/85"
+        >
+          <SkipForward className="h-3.5 w-3.5" aria-hidden="true" />
+          Skip
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/video-player-types.ts
+++ b/apps/web/src/components/video-player-types.ts
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import type { MediaSrc } from "../lib/vidstack";
+import type { SponsorBlockSegmentItem, SubtitleItem } from "../types/api";
+
+export type VideoPlayerProps = {
+  src: MediaSrc;
+  title?: string;
+  poster?: string;
+  streamType?: "on-demand" | "live";
+  startTime?: number;
+  subtitles?: SubtitleItem[];
+  sponsorBlockSegments?: SponsorBlockSegmentItem[];
+  autoSkipSponsorBlockSegments?: SponsorBlockSegmentItem[];
+  manualSkipSponsorBlockSegments?: SponsorBlockSegmentItem[];
+  autoSkipSponsorBlock?: boolean;
+  muteSponsorBlockInsteadOfSkip?: boolean;
+  showCurrentSponsorBlockSegment?: boolean;
+  thumbnailVtt?: string;
+  chaptersVtt?: string;
+  initialVolume?: number;
+  initialMuted?: boolean;
+  settingsReady?: boolean;
+  autoplay?: boolean;
+  originalAudioLocale?: string | null;
+  overlay?: ReactNode;
+  onVolumeChange?: (volume: number, muted: boolean) => void;
+  onTimeUpdate?: (positionMs: number) => void;
+  onPause?: () => void;
+  onSeeked?: () => void;
+  onError?: () => void;
+  onSeekReady?: (seek: (seconds: number) => void) => void;
+  onEnded?: () => void;
+  className?: string;
+  mediaClassName?: string;
+};

--- a/apps/web/src/components/video-player.tsx
+++ b/apps/web/src/components/video-player.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { isIosDevice } from "../lib/ios-device";
-import type { MediaSrc } from "../lib/vidstack";
 import {
   DefaultVideoLayout,
   defaultLayoutIcons,
@@ -8,7 +7,6 @@ import {
   MediaProvider,
   Track,
 } from "../lib/vidstack";
-import type { SponsorBlockSegmentItem, SubtitleItem } from "../types/api";
 import { AudioTrackSelector } from "./audio-track-selector";
 import { CinemaModeControl } from "./cinema-mode-control";
 import { FormatSelector } from "./format-selector";
@@ -17,6 +15,7 @@ import { PlayerHotkeys } from "./player-hotkeys";
 import { PlayerSeeker, SeekBridge, SponsorBlockSkipper } from "./player-internals";
 import { QualitySelector } from "./quality-selector";
 import { SponsorBlockBar } from "./sponsorblock-bar";
+import { SponsorBlockCurrentSegment } from "./sponsorblock-current-segment";
 import {
   type FontSize,
   fontSizeToMultiplier,
@@ -24,34 +23,8 @@ import {
 } from "./subtitle-size-selector";
 import { buildSafeSubtitleTracks } from "./subtitle-track-utils";
 import { ChaptersTrack, onProviderChange } from "./video-player-core";
+import type { VideoPlayerProps } from "./video-player-types";
 import { VolumeRestorer } from "./volume-restorer";
-
-type Props = {
-  src: MediaSrc;
-  title?: string;
-  poster?: string;
-  streamType?: "on-demand" | "live";
-  startTime?: number;
-  subtitles?: SubtitleItem[];
-  sponsorBlockSegments?: SponsorBlockSegmentItem[];
-  thumbnailVtt?: string;
-  chaptersVtt?: string;
-  initialVolume?: number;
-  initialMuted?: boolean;
-  settingsReady?: boolean;
-  autoplay?: boolean;
-  originalAudioLocale?: string | null;
-  overlay?: React.ReactNode;
-  onVolumeChange?: (volume: number, muted: boolean) => void;
-  onTimeUpdate?: (positionMs: number) => void;
-  onPause?: () => void;
-  onSeeked?: () => void;
-  onError?: () => void;
-  onSeekReady?: (seek: (seconds: number) => void) => void;
-  onEnded?: () => void;
-  className?: string;
-  mediaClassName?: string;
-};
 
 export function VideoPlayer({
   src,
@@ -61,6 +34,11 @@ export function VideoPlayer({
   startTime = 0,
   subtitles,
   sponsorBlockSegments,
+  autoSkipSponsorBlockSegments,
+  manualSkipSponsorBlockSegments,
+  autoSkipSponsorBlock = true,
+  muteSponsorBlockInsteadOfSkip = false,
+  showCurrentSponsorBlockSegment = false,
   thumbnailVtt,
   chaptersVtt,
   initialVolume = 1,
@@ -78,7 +56,7 @@ export function VideoPlayer({
   onEnded,
   className,
   mediaClassName,
-}: Props) {
+}: VideoPlayerProps) {
   const ios = isIosDevice();
   const [subtitleSize, setSubtitleSize] = useState<FontSize>("normal");
   const subtitleTracks = buildSafeSubtitleTracks(subtitles);
@@ -164,8 +142,21 @@ export function VideoPlayer({
         isLive={streamType === "live"}
       />
       <PlayerHotkeys canSeek={streamType !== "live"} />
-      {sponsorBlockSegments && <SponsorBlockSkipper segments={sponsorBlockSegments} />}
+      {autoSkipSponsorBlock && autoSkipSponsorBlockSegments && (
+        <SponsorBlockSkipper
+          segments={autoSkipSponsorBlockSegments}
+          muteInsteadOfSkip={muteSponsorBlockInsteadOfSkip}
+        />
+      )}
       {sponsorBlockSegments && <SponsorBlockBar segments={sponsorBlockSegments} />}
+      {showCurrentSponsorBlockSegment && sponsorBlockSegments && (
+        <SponsorBlockCurrentSegment
+          segments={sponsorBlockSegments}
+          autoSkipSegments={autoSkipSponsorBlockSegments}
+          manualSkipSegments={manualSkipSponsorBlockSegments}
+          muteInsteadOfSkip={muteSponsorBlockInsteadOfSkip}
+        />
+      )}
       {onSeekReady && <SeekBridge onSeekReady={onSeekReady} />}
     </MediaPlayer>
   );

--- a/apps/web/src/components/video-player.tsx
+++ b/apps/web/src/components/video-player.tsx
@@ -13,6 +13,7 @@ import { AudioTrackSelector } from "./audio-track-selector";
 import { CinemaModeControl } from "./cinema-mode-control";
 import { FormatSelector } from "./format-selector";
 import { MediaSessionSync } from "./media-session-sync";
+import { PlayerHotkeys } from "./player-hotkeys";
 import { PlayerSeeker, SeekBridge, SponsorBlockSkipper } from "./player-internals";
 import { QualitySelector } from "./quality-selector";
 import { SponsorBlockBar } from "./sponsorblock-bar";
@@ -162,6 +163,7 @@ export function VideoPlayer({
         canSeek={streamType !== "live"}
         isLive={streamType === "live"}
       />
+      <PlayerHotkeys canSeek={streamType !== "live"} />
       {sponsorBlockSegments && <SponsorBlockSkipper segments={sponsorBlockSegments} />}
       {sponsorBlockSegments && <SponsorBlockBar segments={sponsorBlockSegments} />}
       {onSeekReady && <SeekBridge onSeekReady={onSeekReady} />}

--- a/apps/web/src/components/watch-layout-classes.ts
+++ b/apps/web/src/components/watch-layout-classes.ts
@@ -1,0 +1,14 @@
+export function getWatchLayoutClasses(cinemaMode: boolean) {
+  const anim = "[animation:page-fade-in_0.2s_ease-out]";
+  return {
+    containerClass: `flex flex-col gap-6 ${cinemaMode ? "" : "lg:flex-row lg:items-start"} ${anim}`,
+    playerWrapClass: cinemaMode
+      ? "overflow-hidden bg-black"
+      : "min-w-0 flex-[2] max-w-[133.333vh] flex flex-col gap-4",
+    playerBoxClass: cinemaMode
+      ? "mx-auto aspect-video w-[min(100%,calc((100svh-4.5rem)*16/9))]"
+      : "overflow-hidden rounded-lg",
+    playerClassName: cinemaMode ? "w-full h-full dark [--video-aspect-ratio:16/9]" : undefined,
+    mediaClassName: cinemaMode ? "object-cover" : undefined,
+  };
+}

--- a/apps/web/src/components/watch-layout.tsx
+++ b/apps/web/src/components/watch-layout.tsx
@@ -8,6 +8,7 @@ import { useSettings } from "../hooks/use-settings";
 import { useVolumeSync } from "../hooks/use-volume-sync";
 import { useWatchVttAssets } from "../hooks/use-watch-layout-assets";
 import { useWatchPlayerEvents } from "../hooks/use-watch-player-events";
+import { useWatchSponsorBlock } from "../hooks/use-watch-sponsorblock";
 import {
   getOriginalAudioLocale,
   getOriginalAudioTrackId,
@@ -17,13 +18,12 @@ import { detectProvider } from "../lib/provider";
 import { useDanmakuStore } from "../stores/danmaku-store";
 import { useWatchLayoutStore } from "../stores/watch-layout-store";
 import type { VideoStream } from "../types/stream";
-import { DanmakuOverlay } from "./danmaku-overlay";
-import { PlayerDefaults } from "./player-defaults";
 import { PlayerError } from "./player-error";
-import { PlayerFocuser } from "./player-internals";
 import { Toast } from "./toast";
 import { VideoPlayer } from "./video-player";
+import { getWatchLayoutClasses } from "./watch-layout-classes";
 import { WatchMeta } from "./watch-meta";
+import { WatchPlayerOverlay } from "./watch-player-overlay";
 import { WatchSecondaryContent } from "./watch-secondary-content";
 
 type Props = {
@@ -43,7 +43,14 @@ export function WatchLayout({ stream, startTime }: Props) {
   );
   const { on: bulletCommentsOn } = useDanmakuStore();
   const isNicoNico = detectProvider(stream.id) === "nicovideo";
-  const { data: bulletComments } = useBulletComments(stream.id, isNicoNico);
+  const hideComments = settings.hideComments;
+  const {
+    segments: sponsorBlockSegments,
+    autoSkipSegments,
+    manualSkipSegments,
+  } = useWatchSponsorBlock(stream, settings);
+  const relatedStreams = settings.hideRelatedVideos ? [] : (stream.related ?? []);
+  const { data: bulletComments } = useBulletComments(stream.id, isNicoNico && !hideComments);
   const originalTrackId = getOriginalAudioTrackId(stream);
   const preferredAudioTrackId = getPreferredDefaultAudioTrackId(stream);
   const originalLocale = getOriginalAudioLocale(stream);
@@ -51,8 +58,18 @@ export function WatchLayout({ stream, startTime }: Props) {
   const seekRef = useRef<((seconds: number) => void) | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const handleVolumeChange = useVolumeSync(update.mutate);
-  const { thumbnailVtt, chaptersVtt } = useWatchVttAssets(stream);
-  const playerKey = `${stream.id}:${retryKey}:${settings.enableHighQualityPlayback ? "hq" : "std"}`;
+  const { thumbnailVtt, chaptersVtt } = useWatchVttAssets(
+    stream,
+    sponsorBlockSegments,
+    settings.sponsorBlockShowChapters,
+  );
+  const playerKey = [
+    stream.id,
+    retryKey,
+    settings.enableHighQualityPlayback ? "hq" : "std",
+    thumbnailVtt ? "thumbs" : "no-thumbs",
+    chaptersVtt ? "chapters" : "no-chapters",
+  ].join(":");
 
   useEffect(() => {
     if (!toast) return;
@@ -80,36 +97,23 @@ export function WatchLayout({ stream, startTime }: Props) {
   );
 
   const overlay = (
-    <>
-      {isNicoNico && bulletCommentsOn && bulletComments && (
-        <DanmakuOverlay comments={bulletComments} positionRef={playerEvents.positionRef} />
-      )}
-      <PlayerFocuser />
-      <PlayerDefaults
-        defaultQuality={qualityFailed ? undefined : settings.defaultQuality}
-        defaultAudioLanguage={settings.defaultAudioLanguage || undefined}
-        preferOriginalLanguage={settings.preferOriginalLanguage}
-        requireOriginalLanguage
-        onOriginalLanguageUnavailable={() => {
-          setToast("Original audio unavailable");
-        }}
-        originalAudioTrackId={originalTrackId}
-        preferredDefaultAudioTrackId={preferredAudioTrackId}
-        originalAudioLocale={originalLocale}
-        subtitlesEnabled={settings.subtitlesEnabled}
-        defaultSubtitleLanguage={settings.defaultSubtitleLanguage || undefined}
-      />
-    </>
+    <WatchPlayerOverlay
+      isNicoNico={isNicoNico}
+      hideComments={hideComments}
+      bulletCommentsOn={bulletCommentsOn}
+      bulletComments={bulletComments}
+      positionRef={playerEvents.positionRef}
+      settings={settings}
+      qualityFailed={qualityFailed}
+      onOriginalLanguageUnavailable={() => setToast("Original audio unavailable")}
+      originalAudioTrackId={originalTrackId}
+      preferredDefaultAudioTrackId={preferredAudioTrackId}
+      originalAudioLocale={originalLocale}
+    />
   );
 
-  const anim = "[animation:page-fade-in_0.2s_ease-out]";
-  const containerClass = `flex flex-col gap-6 ${cinemaMode ? "" : "lg:flex-row lg:items-start"} ${anim}`;
-  const playerWrapClass = cinemaMode
-    ? "overflow-hidden bg-black"
-    : "min-w-0 flex-[2] max-w-[133.333vh] flex flex-col gap-4";
-  const playerBoxClass = cinemaMode
-    ? "mx-auto aspect-video w-[min(100%,calc((100svh-4.5rem)*16/9))]"
-    : "overflow-hidden rounded-lg";
+  const { containerClass, playerWrapClass, playerBoxClass, playerClassName, mediaClassName } =
+    getWatchLayoutClasses(cinemaMode);
 
   return (
     <div className={containerClass}>
@@ -125,7 +129,12 @@ export function WatchLayout({ stream, startTime }: Props) {
                 streamType={isLive ? "live" : "on-demand"}
                 startTime={retryStartTime > 0 ? retryStartTime : startTime}
                 subtitles={stream.subtitles}
-                sponsorBlockSegments={stream.sponsorBlockSegments}
+                sponsorBlockSegments={sponsorBlockSegments}
+                autoSkipSponsorBlock={Boolean(autoSkipSegments)}
+                autoSkipSponsorBlockSegments={autoSkipSegments}
+                manualSkipSponsorBlockSegments={manualSkipSegments}
+                muteSponsorBlockInsteadOfSkip={settings.sponsorBlockMuteInsteadOfSkip}
+                showCurrentSponsorBlockSegment={settings.sponsorBlockShowCurrentSegment}
                 thumbnailVtt={thumbnailVtt}
                 chaptersVtt={chaptersVtt}
                 initialVolume={settings.volume}
@@ -140,13 +149,9 @@ export function WatchLayout({ stream, startTime }: Props) {
                 onSeeked={playerEvents.handleSeeked}
                 onError={handlePlayerError}
                 onEnded={playerEvents.handleEnded}
-                onSeekReady={(s) => {
-                  seekRef.current = s;
-                }}
-                className={
-                  cinemaMode ? "w-full h-full dark [--video-aspect-ratio:16/9]" : undefined
-                }
-                mediaClassName={cinemaMode ? "object-cover" : undefined}
+                onSeekReady={(s) => (seekRef.current = s)}
+                className={playerClassName}
+                mediaClassName={mediaClassName}
               />
               {playerFailed && <PlayerError onRetry={reset} />}
             </>
@@ -154,12 +159,19 @@ export function WatchLayout({ stream, startTime }: Props) {
             <div className="aspect-video w-full bg-black" />
           )}
         </div>
-        {!cinemaMode && <WatchMeta stream={stream} onSeekTimestamp={(s) => seekRef.current?.(s)} />}
+        {!cinemaMode && (
+          <WatchMeta
+            stream={stream}
+            showComments={!hideComments}
+            onSeekTimestamp={(s) => seekRef.current?.(s)}
+          />
+        )}
       </div>
       <WatchSecondaryContent
         cinemaMode={cinemaMode}
         stream={stream}
-        relatedStreams={stream.related ?? []}
+        relatedStreams={relatedStreams}
+        showComments={!hideComments}
         onSeekTimestamp={(seconds) => seekRef.current?.(seconds)}
       />
       <Toast message={toast} />

--- a/apps/web/src/components/watch-player-defaults.tsx
+++ b/apps/web/src/components/watch-player-defaults.tsx
@@ -1,0 +1,39 @@
+import type { SettingsItem } from "../types/user";
+import { PlayerDefaults } from "./player-defaults";
+import { PlayerFocuser } from "./player-internals";
+
+type Props = {
+  settings: SettingsItem;
+  qualityFailed: boolean;
+  originalAudioTrackId?: string | null;
+  preferredDefaultAudioTrackId?: string | null;
+  originalAudioLocale?: string | null;
+  onOriginalLanguageUnavailable: () => void;
+};
+
+export function WatchPlayerDefaults({
+  settings,
+  qualityFailed,
+  originalAudioTrackId,
+  preferredDefaultAudioTrackId,
+  originalAudioLocale,
+  onOriginalLanguageUnavailable,
+}: Props) {
+  return (
+    <>
+      <PlayerFocuser />
+      <PlayerDefaults
+        defaultQuality={qualityFailed ? undefined : settings.defaultQuality}
+        defaultAudioLanguage={settings.defaultAudioLanguage || undefined}
+        preferOriginalLanguage={settings.preferOriginalLanguage}
+        requireOriginalLanguage
+        onOriginalLanguageUnavailable={onOriginalLanguageUnavailable}
+        originalAudioTrackId={originalAudioTrackId}
+        preferredDefaultAudioTrackId={preferredDefaultAudioTrackId}
+        originalAudioLocale={originalAudioLocale}
+        subtitlesEnabled={settings.subtitlesEnabled}
+        defaultSubtitleLanguage={settings.defaultSubtitleLanguage || undefined}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/watch-player-overlay.tsx
+++ b/apps/web/src/components/watch-player-overlay.tsx
@@ -1,0 +1,49 @@
+import type { RefObject } from "react";
+import type { BulletCommentItem } from "../types/api";
+import type { SettingsItem } from "../types/user";
+import { DanmakuOverlay } from "./danmaku-overlay";
+import { WatchPlayerDefaults } from "./watch-player-defaults";
+
+type Props = {
+  isNicoNico: boolean;
+  hideComments: boolean;
+  bulletCommentsOn: boolean;
+  bulletComments: BulletCommentItem[] | undefined;
+  positionRef: RefObject<number>;
+  settings: SettingsItem;
+  qualityFailed: boolean;
+  originalAudioTrackId: string | null;
+  preferredDefaultAudioTrackId: string | null;
+  originalAudioLocale: string | null;
+  onOriginalLanguageUnavailable: () => void;
+};
+
+export function WatchPlayerOverlay({
+  isNicoNico,
+  hideComments,
+  bulletCommentsOn,
+  bulletComments,
+  positionRef,
+  settings,
+  qualityFailed,
+  originalAudioTrackId,
+  preferredDefaultAudioTrackId,
+  originalAudioLocale,
+  onOriginalLanguageUnavailable,
+}: Props) {
+  return (
+    <>
+      {isNicoNico && !hideComments && bulletCommentsOn && bulletComments && (
+        <DanmakuOverlay comments={bulletComments} positionRef={positionRef} />
+      )}
+      <WatchPlayerDefaults
+        settings={settings}
+        qualityFailed={qualityFailed}
+        onOriginalLanguageUnavailable={onOriginalLanguageUnavailable}
+        originalAudioTrackId={originalAudioTrackId}
+        preferredDefaultAudioTrackId={preferredDefaultAudioTrackId}
+        originalAudioLocale={originalAudioLocale}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/watch-secondary-content.tsx
+++ b/apps/web/src/components/watch-secondary-content.tsx
@@ -6,6 +6,7 @@ type Props = {
   cinemaMode: boolean;
   stream: VideoStream;
   relatedStreams: VideoStream[];
+  showComments: boolean;
   onSeekTimestamp: (seconds: number) => void;
 };
 
@@ -13,6 +14,7 @@ export function WatchSecondaryContent({
   cinemaMode,
   stream,
   relatedStreams,
+  showComments,
   onSeekTimestamp,
 }: Props) {
   if (!cinemaMode) {
@@ -26,7 +28,7 @@ export function WatchSecondaryContent({
   return (
     <div className="mx-auto flex w-full max-w-[1700px] flex-col gap-6 px-4 lg:flex-row lg:items-start">
       <div className="min-w-0 flex-[2] max-w-[1200px] flex flex-col gap-4">
-        <WatchMeta stream={stream} onSeekTimestamp={onSeekTimestamp} />
+        <WatchMeta stream={stream} showComments={showComments} onSeekTimestamp={onSeekTimestamp} />
       </div>
       <div className="w-full lg:flex-1 lg:min-w-64">
         <RelatedVideos streams={relatedStreams} />

--- a/apps/web/src/hooks/use-home-recommendations.ts
+++ b/apps/web/src/hooks/use-home-recommendations.ts
@@ -33,7 +33,7 @@ export function useHomeRecommendations(): Result {
       ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (last) => (last.hasMore ? (last.nextCursor ?? undefined) : undefined),
-    enabled: authReady && isAuthed,
+    enabled: authReady && isAuthed && !settings.hideHomeRecommendations,
     staleTime: 90 * 1000,
   });
 

--- a/apps/web/src/hooks/use-settings.ts
+++ b/apps/web/src/hooks/use-settings.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchSettings, updateSettings } from "../lib/api-user";
+import { DEFAULT_SPONSORBLOCK_CATEGORY_ACTIONS } from "../lib/sponsorblock-settings";
 import type { SettingsItem } from "../types/user";
 import { useAuth } from "./use-auth";
 
@@ -16,6 +17,19 @@ const DEFAULTS: SettingsItem = {
   defaultAudioLanguage: "",
   preferOriginalLanguage: true,
   enableHighQualityPlayback: false,
+  sponsorBlockMode: "auto_skip",
+  sponsorBlockCategoryActions: DEFAULT_SPONSORBLOCK_CATEGORY_ACTIONS,
+  sponsorBlockMinimumDuration: 0,
+  sponsorBlockShowCurrentSegment: true,
+  sponsorBlockShowChapters: false,
+  sponsorBlockShowFullVideoLabels: true,
+  sponsorBlockManualSkipOnFullVideo: true,
+  sponsorBlockSkipNonMusicOnlyOnMusicVideos: false,
+  sponsorBlockMuteInsteadOfSkip: false,
+  hideHomeRecommendations: false,
+  hideRelatedVideos: false,
+  hideComments: false,
+  hideShorts: false,
 };
 
 export function useSettings() {

--- a/apps/web/src/hooks/use-shorts-feed.ts
+++ b/apps/web/src/hooks/use-shorts-feed.ts
@@ -43,7 +43,7 @@ export function useShortsFeed(): ShortsFeed {
       ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (last) => (last.hasMore ? (last.nextCursor ?? undefined) : undefined),
-    enabled: authReady && isAuthed,
+    enabled: authReady && isAuthed && !settings.hideShorts,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -56,7 +56,12 @@ export function useShortsFeed(): ShortsFeed {
       fetchSubscriptionShorts(pageParam as number, 30, settings.defaultService, true),
     initialPageParam: 0,
     getNextPageParam: (last) => parseNextPage(last.nextpage),
-    enabled: authReady && isAuthed && recommendations.isSuccess && !hasRecommendationShorts,
+    enabled:
+      authReady &&
+      isAuthed &&
+      !settings.hideShorts &&
+      recommendations.isSuccess &&
+      !hasRecommendationShorts,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -66,7 +71,7 @@ export function useShortsFeed(): ShortsFeed {
       fetchSearch(SHORTS_QUERY, settings.defaultService, pageParam as string | undefined),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (last) => last.nextpage ?? undefined,
-    enabled: authReady && !isAuthed,
+    enabled: authReady && !isAuthed && !settings.hideShorts,
     staleTime: 90 * 1000,
   });
 
@@ -90,8 +95,13 @@ export function useShortsFeed(): ShortsFeed {
   const useRecommendations = authReady && isAuthed && hasRecommendationShorts;
   return {
     shorts,
-    isLoading:
-      shorts.length > 0 ? false : isAuthed ? recommendations.isLoading : discovery.isLoading,
+    isLoading: settings.hideShorts
+      ? false
+      : shorts.length > 0
+        ? false
+        : isAuthed
+          ? recommendations.isLoading
+          : discovery.isLoading,
     isFetchingNextPage: isAuthed
       ? useRecommendations
         ? recommendations.isFetchingNextPage

--- a/apps/web/src/hooks/use-watch-layout-assets.ts
+++ b/apps/web/src/hooks/use-watch-layout-assets.ts
@@ -25,7 +25,9 @@ export function useWatchVttAssets(
     const vtt = buildThumbnailVtt(proxied);
     setThumbnailVtt(vtt);
     return () => {
-      URL.revokeObjectURL(vtt);
+      if (vtt) {
+        URL.revokeObjectURL(vtt);
+      }
     };
   }, [stream.previewFrames]);
 

--- a/apps/web/src/hooks/use-watch-layout-assets.ts
+++ b/apps/web/src/hooks/use-watch-layout-assets.ts
@@ -1,39 +1,48 @@
-import { useEffect, useRef } from "react";
-import { buildChaptersVtt } from "../lib/chapters-vtt";
+import { useEffect, useState } from "react";
+import { buildChaptersVtt, buildSponsorBlockChaptersVtt } from "../lib/chapters-vtt";
 import { proxyUrl } from "../lib/proxy";
 import { buildThumbnailVtt } from "../lib/thumbnail-vtt";
+import type { SponsorBlockSegmentItem } from "../types/api";
 import type { VideoStream } from "../types/stream";
 
-export function useWatchVttAssets(stream: VideoStream) {
-  const thumbnailVtt = useRef<string | null>(null);
-  const chaptersVtt = useRef<string | null>(null);
+export function useWatchVttAssets(
+  stream: VideoStream,
+  sponsorBlockSegments: SponsorBlockSegmentItem[] | undefined,
+  showSponsorBlockChapters: boolean,
+) {
+  const [thumbnailVtt, setThumbnailVtt] = useState<string | null>(null);
+  const [chaptersVtt, setChaptersVtt] = useState<string | null>(null);
 
   useEffect(() => {
     if (!stream.previewFrames) {
-      thumbnailVtt.current = null;
+      setThumbnailVtt(null);
       return;
     }
     const proxied = stream.previewFrames.map((frame) => ({
       ...frame,
       urls: frame.urls.map(proxyUrl),
     }));
-    thumbnailVtt.current = buildThumbnailVtt(proxied);
+    const vtt = buildThumbnailVtt(proxied);
+    setThumbnailVtt(vtt);
     return () => {
-      if (thumbnailVtt.current) URL.revokeObjectURL(thumbnailVtt.current);
+      URL.revokeObjectURL(vtt);
     };
   }, [stream.previewFrames]);
 
   useEffect(() => {
-    chaptersVtt.current = stream.streamSegments
+    const vtt = stream.streamSegments
       ? buildChaptersVtt(stream.streamSegments, stream.duration)
-      : null;
+      : showSponsorBlockChapters
+        ? buildSponsorBlockChaptersVtt(sponsorBlockSegments ?? [], stream.duration)
+        : null;
+    setChaptersVtt(vtt);
     return () => {
-      if (chaptersVtt.current) URL.revokeObjectURL(chaptersVtt.current);
+      if (vtt) URL.revokeObjectURL(vtt);
     };
-  }, [stream.streamSegments, stream.duration]);
+  }, [stream.streamSegments, stream.duration, sponsorBlockSegments, showSponsorBlockChapters]);
 
   return {
-    thumbnailVtt: thumbnailVtt.current ?? undefined,
-    chaptersVtt: chaptersVtt.current ?? undefined,
+    thumbnailVtt: thumbnailVtt ?? undefined,
+    chaptersVtt: chaptersVtt ?? undefined,
   };
 }

--- a/apps/web/src/hooks/use-watch-sponsorblock.ts
+++ b/apps/web/src/hooks/use-watch-sponsorblock.ts
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import {
+  filterAutoSkipSponsorBlockSegments,
+  filterManualSponsorBlockSegments,
+  filterSponsorBlockSegments,
+} from "../lib/sponsorblock-settings";
+import type { VideoStream } from "../types/stream";
+import type { SettingsItem } from "../types/user";
+
+export function useWatchSponsorBlock(stream: VideoStream, settings: SettingsItem) {
+  const segments = useMemo(
+    () => filterSponsorBlockSegments(stream.sponsorBlockSegments, settings, stream.duration),
+    [stream.sponsorBlockSegments, stream.duration, settings],
+  );
+  const autoSkipSegments = useMemo(
+    () => filterAutoSkipSponsorBlockSegments(segments, settings, stream.duration, stream.category),
+    [segments, settings, stream.duration, stream.category],
+  );
+  const manualSkipSegments = useMemo(
+    () => filterManualSponsorBlockSegments(segments, settings, stream.duration),
+    [segments, settings, stream.duration],
+  );
+
+  return {
+    segments,
+    autoSkipSegments,
+    manualSkipSegments,
+  };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,6 +4,7 @@
 @import "./styles/theme.css";
 @import "./styles/shorts-overrides.css";
 @import "./styles/player-menu-overrides.css";
+@import "./styles/player-hotkeys.css";
 
 @keyframes card-pop-in {
   from {

--- a/apps/web/src/lib/chapters-vtt.ts
+++ b/apps/web/src/lib/chapters-vtt.ts
@@ -1,4 +1,9 @@
-import type { StreamSegmentItem } from "../types/api";
+import type { SponsorBlockSegmentItem, StreamSegmentItem } from "../types/api";
+import {
+  getSponsorBlockCategoryLabel,
+  getSponsorBlockEndTime,
+  getSponsorBlockStartTime,
+} from "./sponsorblock-settings";
 
 function formatVttTime(seconds: number): string {
   const totalSeconds = Math.floor(seconds);
@@ -28,6 +33,28 @@ export function buildChaptersVtt(
     lines.push(seg.title);
     lines.push("");
   }
+
+  const blob = new Blob([lines.join("\n")], { type: "text/vtt" });
+  return URL.createObjectURL(blob);
+}
+
+export function buildSponsorBlockChaptersVtt(
+  segments: SponsorBlockSegmentItem[],
+  durationSeconds: number,
+): string | null {
+  if (segments.length === 0) return null;
+
+  const sorted = [...segments].sort((a, b) => a.startTime - b.startTime);
+  const lines: string[] = ["WEBVTT", ""];
+
+  sorted.forEach((segment, index) => {
+    lines.push(String(index + 1));
+    lines.push(
+      `${formatVttTime(getSponsorBlockStartTime(segment, durationSeconds))} --> ${formatVttTime(getSponsorBlockEndTime(segment, durationSeconds))}`,
+    );
+    lines.push(getSponsorBlockCategoryLabel(segment.category));
+    lines.push("");
+  });
 
   const blob = new Blob([lines.join("\n")], { type: "text/vtt" });
   return URL.createObjectURL(blob);

--- a/apps/web/src/lib/sponsorblock-settings.ts
+++ b/apps/web/src/lib/sponsorblock-settings.ts
@@ -1,0 +1,180 @@
+import type { SponsorBlockSegmentItem } from "../types/api";
+import type { SettingsItem, SponsorBlockCategoryAction } from "../types/user";
+
+export type SponsorBlockCategory = {
+  id: string;
+  label: string;
+  description: string;
+  color: string;
+  defaultAction: SponsorBlockCategoryAction;
+};
+
+export const SPONSORBLOCK_CATEGORIES: SponsorBlockCategory[] = [
+  {
+    id: "sponsor",
+    label: "Sponsored message",
+    description: "Paid promotion, sponsorship, or direct advertising.",
+    color: "#00d400",
+    defaultAction: "auto_skip",
+  },
+  {
+    id: "selfpromo",
+    label: "Self-promotion",
+    description: "Unpaid promotion, merch, donations, or guest promotion.",
+    color: "#ffff00",
+    defaultAction: "auto_skip",
+  },
+  {
+    id: "exclusive_access",
+    label: "Exclusive access",
+    description: "Whole-video labels for free or subsidized access.",
+    color: "#008a5c",
+    defaultAction: "mark_only",
+  },
+  {
+    id: "interaction",
+    label: "Interaction reminder",
+    description: "Short reminders to like, subscribe, or follow.",
+    color: "#cc00ff",
+    defaultAction: "auto_skip",
+  },
+  {
+    id: "poi_highlight",
+    label: "Highlight",
+    description: "The main point most viewers are looking for.",
+    color: "#ff1684",
+    defaultAction: "mark_only",
+  },
+  {
+    id: "intro",
+    label: "Intermission or intro",
+    description: "Low-content pauses, static screens, or repeated animations.",
+    color: "#00ffff",
+    defaultAction: "auto_skip",
+  },
+  {
+    id: "outro",
+    label: "Endcards or credits",
+    description: "Credits or YouTube end screens without useful conclusions.",
+    color: "#0202ed",
+    defaultAction: "auto_skip",
+  },
+  {
+    id: "preview",
+    label: "Preview or recap",
+    description: "Clips repeated later in the same video or series.",
+    color: "#008fd6",
+    defaultAction: "auto_skip",
+  },
+  {
+    id: "filler",
+    label: "Tangents or jokes",
+    description: "Aggressive skipping for non-essential tangents or jokes.",
+    color: "#7300ff",
+    defaultAction: "auto_skip",
+  },
+  {
+    id: "chapter",
+    label: "Chapter",
+    description: "Custom chapters describing important sections.",
+    color: "#ffd000",
+    defaultAction: "mark_only",
+  },
+  {
+    id: "music_offtopic",
+    label: "Music: non-music",
+    description: "Non-musical sections in music videos.",
+    color: "#ff9900",
+    defaultAction: "auto_skip",
+  },
+];
+
+export const DEFAULT_SPONSORBLOCK_CATEGORY_ACTIONS = Object.fromEntries(
+  SPONSORBLOCK_CATEGORIES.map((category) => [category.id, category.defaultAction]),
+);
+
+export function getSponsorBlockCategoryColor(categoryId: string) {
+  return SPONSORBLOCK_CATEGORIES.find((category) => category.id === categoryId)?.color;
+}
+
+export function getSponsorBlockCategoryLabel(categoryId: string) {
+  return (
+    SPONSORBLOCK_CATEGORIES.find((category) => category.id === categoryId)?.label ?? categoryId
+  );
+}
+
+function isMusicVideo(category: string | undefined) {
+  return category?.toLowerCase() === "music";
+}
+
+function isFullVideoSponsorBlockSegment(segment: SponsorBlockSegmentItem, duration: number) {
+  if (duration <= 0) return false;
+  return (
+    getSponsorBlockStartTime(segment, duration) <= 5 &&
+    getSponsorBlockEndTime(segment, duration) >= duration * 0.9
+  );
+}
+
+export function getSponsorBlockStartTime(segment: SponsorBlockSegmentItem, duration: number) {
+  return shouldNormalizeMilliseconds(segment, duration)
+    ? segment.startTime / 1000
+    : segment.startTime;
+}
+
+export function getSponsorBlockEndTime(segment: SponsorBlockSegmentItem, duration: number) {
+  return shouldNormalizeMilliseconds(segment, duration) ? segment.endTime / 1000 : segment.endTime;
+}
+
+function shouldNormalizeMilliseconds(segment: SponsorBlockSegmentItem, duration: number) {
+  return duration > 0 && segment.endTime > duration + 30;
+}
+
+export function filterSponsorBlockSegments(
+  segments: SponsorBlockSegmentItem[] | undefined,
+  settings: SettingsItem,
+  duration: number,
+) {
+  if (!segments || settings.sponsorBlockMode === "disabled") return undefined;
+  const minimumSeconds = Math.max(0, settings.sponsorBlockMinimumDuration);
+  const visible = segments.filter((segment) => {
+    const action = settings.sponsorBlockCategoryActions[segment.category] ?? "mark_only";
+    const segmentDuration =
+      getSponsorBlockEndTime(segment, duration) - getSponsorBlockStartTime(segment, duration);
+    if (action === "disabled" || segmentDuration < minimumSeconds) return false;
+    return (
+      settings.sponsorBlockShowFullVideoLabels || !isFullVideoSponsorBlockSegment(segment, duration)
+    );
+  });
+  return visible.length > 0 ? visible : undefined;
+}
+
+export function filterAutoSkipSponsorBlockSegments(
+  segments: SponsorBlockSegmentItem[] | undefined,
+  settings: SettingsItem,
+  duration: number,
+  streamCategory: string | undefined,
+) {
+  if (!segments || settings.sponsorBlockMode !== "auto_skip") return undefined;
+  const skipped = segments.filter((segment) => {
+    if (settings.sponsorBlockCategoryActions[segment.category] !== "auto_skip") return false;
+    if (
+      settings.sponsorBlockManualSkipOnFullVideo &&
+      isFullVideoSponsorBlockSegment(segment, duration)
+    ) {
+      return false;
+    }
+    if (segment.category !== "music_offtopic") return true;
+    return !settings.sponsorBlockSkipNonMusicOnlyOnMusicVideos || isMusicVideo(streamCategory);
+  });
+  return skipped.length > 0 ? skipped : undefined;
+}
+
+export function filterManualSponsorBlockSegments(
+  segments: SponsorBlockSegmentItem[] | undefined,
+  settings: SettingsItem,
+  duration: number,
+) {
+  if (!segments || !settings.sponsorBlockManualSkipOnFullVideo) return undefined;
+  const manual = segments.filter((segment) => isFullVideoSponsorBlockSegment(segment, duration));
+  return manual.length > 0 ? manual : undefined;
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,9 +3,11 @@ import { ContinueWatching } from "../components/continue-watching";
 import { HomeFallbackSection } from "../components/home-fallback-section";
 import { HomeRecommendationsSection } from "../components/home-recommendations-section";
 import { useAuth } from "../hooks/use-auth";
+import { useSettings } from "../hooks/use-settings";
 
 function HomePage() {
   const { authReady, isAuthed } = useAuth();
+  const { settings } = useSettings();
   if (!authReady) {
     return (
       <div className="min-h-[40vh] flex items-center justify-center">
@@ -14,14 +16,17 @@ function HomePage() {
     );
   }
   const title = isAuthed ? "Recommended" : "Trending";
+  const showRecommendations = !isAuthed || !settings.hideHomeRecommendations;
 
   return (
     <div className="flex flex-col gap-6 sm:gap-8">
       <ContinueWatching />
-      <section className="flex flex-col gap-3">
-        <p className="text-xs font-medium uppercase tracking-wider text-fg-soft">{title}</p>
-        {isAuthed ? <HomeRecommendationsSection /> : <HomeFallbackSection />}
-      </section>
+      {showRecommendations && (
+        <section className="flex flex-col gap-3">
+          <p className="text-xs font-medium uppercase tracking-wider text-fg-soft">{title}</p>
+          {isAuthed ? <HomeRecommendationsSection /> : <HomeFallbackSection />}
+        </section>
+      )}
     </div>
   );
 }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -6,6 +6,7 @@ import { SettingsLanguage } from "../settings/settings-language";
 import { SettingsPlayback } from "../settings/settings-playback";
 import { SettingsPrivacy } from "../settings/settings-privacy";
 import { SettingsService } from "../settings/settings-service";
+import { SettingsVideoPreferences } from "../settings/settings-video-preferences";
 
 function SettingsPage() {
   const { settings } = useSettings();
@@ -14,6 +15,7 @@ function SettingsPage() {
     <div className="flex flex-col gap-6 sm:gap-8 [animation:page-fade-in_0.2s_ease-out]">
       <h1 className="text-lg font-semibold text-fg">Settings</h1>
       <SettingsPlayback />
+      <SettingsVideoPreferences />
       {settings.defaultService === 0 && <SettingsLanguage />}
       <SettingsService />
       <section className="flex flex-col gap-3">

--- a/apps/web/src/routes/shorts.tsx
+++ b/apps/web/src/routes/shorts.tsx
@@ -2,6 +2,8 @@ import { createFileRoute } from "@tanstack/react-router";
 import { X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { ShortsPlayerShell } from "../components/shorts-player-shell";
+import { useSettings } from "../hooks/use-settings";
+import { goto } from "../lib/route-redirect";
 
 const SHORTS_BETA_BANNER_KEY = "shorts-beta-banner-dismissed";
 
@@ -44,6 +46,24 @@ function ShortsBetaBanner() {
 
 function ShortsPage() {
   const { v } = Route.useSearch();
+  const { settings } = useSettings();
+  if (settings.hideShorts) {
+    return (
+      <div className="flex min-h-[45vh] items-center justify-center px-4">
+        <div className="flex max-w-sm flex-col items-center gap-3 rounded-xl border border-border bg-surface px-5 py-6 text-center">
+          <h1 className="text-base font-semibold text-fg">Shorts are hidden</h1>
+          <p className="text-sm text-fg-soft">You can re-enable Shorts from video preferences.</p>
+          <button
+            type="button"
+            onClick={() => goto("/settings")}
+            className="mt-1 h-9 rounded-lg bg-fg px-4 text-sm font-medium text-bg transition-opacity hover:opacity-90"
+          >
+            Open settings
+          </button>
+        </div>
+      </div>
+    );
+  }
   return (
     <>
       <ShortsBetaBanner />

--- a/apps/web/src/settings/settings-content-toggles.tsx
+++ b/apps/web/src/settings/settings-content-toggles.tsx
@@ -1,0 +1,108 @@
+import { useSettings } from "../hooks/use-settings";
+import type { SettingsItem } from "../types/user";
+
+const ROW = "flex items-center justify-between gap-4 px-4 py-4";
+
+type ToggleKey = Extract<
+  keyof SettingsItem,
+  "autoplay" | "hideHomeRecommendations" | "hideRelatedVideos" | "hideComments" | "hideShorts"
+>;
+
+type ToggleOption = {
+  key: ToggleKey;
+  label: string;
+  description: string;
+  area: string;
+};
+
+const WATCH_OPTIONS: ToggleOption[] = [
+  {
+    key: "autoplay",
+    label: "Autoplay next video",
+    description: "Automatically continue with the first item in the suggestions column.",
+    area: "Watch",
+  },
+  {
+    key: "hideRelatedVideos",
+    label: "Related videos",
+    description: "Hide the suggestions column on watch pages.",
+    area: "Watch",
+  },
+  {
+    key: "hideComments",
+    label: "Comments and danmaku",
+    description: "Stop loading watch comments, Shorts comments, and bullet comments.",
+    area: "Watch + Shorts",
+  },
+];
+
+const DISCOVERY_OPTIONS: ToggleOption[] = [
+  {
+    key: "hideHomeRecommendations",
+    label: "Home recommendations",
+    description: "Hide personalized recommendations from the home page.",
+    area: "Home",
+  },
+  {
+    key: "hideShorts",
+    label: "Shorts surface",
+    description: "Hide Shorts navigation and block the Shorts page.",
+    area: "Shorts",
+  },
+];
+
+function ToggleSwitch({ checked, onClick }: { checked: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={onClick}
+      className={`relative h-5 w-10 flex-shrink-0 rounded-full transition-colors duration-200 ${
+        checked ? "bg-fg" : "bg-surface-soft"
+      }`}
+    >
+      <span
+        className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full transition-all duration-200 ${
+          checked ? "translate-x-5 bg-surface" : "translate-x-0 bg-surface-soft"
+        }`}
+      />
+    </button>
+  );
+}
+
+function ToggleRows({ options }: { options: ToggleOption[] }) {
+  const { settings, update } = useSettings();
+  return options.map((option) => (
+    <div key={option.key} className={ROW}>
+      <div className="flex flex-col gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm text-fg">{option.label}</span>
+          <span className="rounded-full bg-surface-soft px-2 py-0.5 text-[10px] text-fg-soft">
+            {option.area}
+          </span>
+        </div>
+        <span className="text-xs text-fg-soft">{option.description}</span>
+      </div>
+      <ToggleSwitch
+        checked={settings[option.key]}
+        onClick={() => update.mutate({ [option.key]: !settings[option.key] })}
+      />
+    </div>
+  ));
+}
+
+export function SettingsContentToggles() {
+  return (
+    <>
+      <div className="bg-surface-soft/30 px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-fg-soft">
+        Watch page
+      </div>
+      <ToggleRows options={WATCH_OPTIONS} />
+      <div className="bg-surface-soft/30 px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-fg-soft">
+        Discovery surfaces
+      </div>
+      <ToggleRows options={DISCOVERY_OPTIONS} />
+    </>
+  );
+}

--- a/apps/web/src/settings/settings-sponsorblock-preferences.tsx
+++ b/apps/web/src/settings/settings-sponsorblock-preferences.tsx
@@ -1,0 +1,160 @@
+import { useSettings } from "../hooks/use-settings";
+import { SPONSORBLOCK_CATEGORIES, type SponsorBlockCategory } from "../lib/sponsorblock-settings";
+import type { SponsorBlockCategoryAction, SponsorBlockMode } from "../types/user";
+
+const ACTIONS: { value: SponsorBlockCategoryAction; label: string }[] = [
+  { value: "auto_skip", label: "Skip" },
+  { value: "mark_only", label: "Mark" },
+  { value: "disabled", label: "Hide" },
+];
+
+const MODES: { value: SponsorBlockMode; label: string; description: string }[] = [
+  { value: "auto_skip", label: "Skip", description: "Use category rules for automatic skips." },
+  { value: "mark_only", label: "Mark", description: "Show matching segments without skipping." },
+  { value: "disabled", label: "Off", description: "Ignore all SponsorBlock data." },
+];
+
+function GlobalMode() {
+  const { settings, update } = useSettings();
+  return (
+    <div className="flex flex-col gap-3 px-4 py-4">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm text-fg">SponsorBlock behavior</span>
+        <span className="text-xs text-fg-soft">
+          Global behavior first, then category rules decide what gets skipped or marked.
+        </span>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-3">
+        {MODES.map((option) => {
+          const selected = settings.sponsorBlockMode === option.value;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => update.mutate({ sponsorBlockMode: option.value })}
+              className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                selected
+                  ? "border-fg bg-surface-strong text-fg"
+                  : "border-border bg-surface text-fg-muted hover:bg-surface-strong hover:text-fg"
+              }`}
+            >
+              <span className="block text-xs font-medium">{option.label}</span>
+              <span className="mt-1 block text-[11px] leading-4 text-fg-soft">
+                {option.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function CategoryAction({ category }: { category: SponsorBlockCategory }) {
+  const { settings, update } = useSettings();
+  const value = settings.sponsorBlockCategoryActions[category.id] ?? category.defaultAction;
+  return (
+    <div className="grid gap-3 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_190px] sm:items-center">
+      <div className="flex min-w-0 gap-3">
+        <span
+          className="mt-1 h-3 w-3 flex-shrink-0 rounded-full border border-border"
+          style={{ backgroundColor: category.color }}
+        />
+        <div className="min-w-0">
+          <div className="text-sm text-fg">{category.label}</div>
+          <div className="text-xs leading-5 text-fg-soft">{category.description}</div>
+        </div>
+      </div>
+      <div className="grid grid-cols-3 rounded-lg border border-border bg-surface-soft p-1">
+        {ACTIONS.map((action) => {
+          const selected = action.value === value;
+          return (
+            <button
+              key={action.value}
+              type="button"
+              onClick={() =>
+                update.mutate({
+                  sponsorBlockCategoryActions: {
+                    ...settings.sponsorBlockCategoryActions,
+                    [category.id]: action.value,
+                  },
+                })
+              }
+              className={`rounded-md px-2 py-1.5 text-[11px] transition-colors ${
+                selected ? "bg-surface text-fg shadow-sm" : "text-fg-soft hover:text-fg"
+              }`}
+            >
+              {action.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ExtraToggles() {
+  const { settings, update } = useSettings();
+  const toggles = [
+    ["sponsorBlockShowCurrentSegment", "Show current segment next to time"],
+    ["sponsorBlockShowChapters", "Show SponsorBlock chapters"],
+    ["sponsorBlockShowFullVideoLabels", "Show full-video labels"],
+    ["sponsorBlockManualSkipOnFullVideo", "Manual skip for full-video labels"],
+    ["sponsorBlockSkipNonMusicOnlyOnMusicVideos", "Skip non-music only on music videos"],
+    ["sponsorBlockMuteInsteadOfSkip", "Mute segments instead of skipping"],
+  ] as const;
+  return toggles.map(([key, label]) => (
+    <button
+      key={key}
+      type="button"
+      role="switch"
+      aria-checked={settings[key]}
+      onClick={() => update.mutate({ [key]: !settings[key] })}
+      className="flex items-center justify-between gap-3 px-4 py-3 text-left text-sm text-fg"
+    >
+      <span>{label}</span>
+      <span
+        className={`h-5 w-10 rounded-full p-0.5 transition-colors ${
+          settings[key] ? "bg-fg" : "bg-surface-soft"
+        }`}
+      >
+        <span
+          className={`block h-4 w-4 rounded-full transition-transform ${
+            settings[key] ? "translate-x-5 bg-surface" : "bg-surface-soft"
+          }`}
+        />
+      </span>
+    </button>
+  ));
+}
+
+export function SettingsSponsorBlockPreferences() {
+  const { settings, update } = useSettings();
+  return (
+    <>
+      <GlobalMode />
+      <div className="bg-surface-soft/30 px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-fg-soft">
+        SponsorBlock categories
+      </div>
+      {SPONSORBLOCK_CATEGORIES.map((category) => (
+        <CategoryAction key={category.id} category={category} />
+      ))}
+      <div className="bg-surface-soft/30 px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-fg-soft">
+        Advanced display
+      </div>
+      <div className="flex items-center justify-between gap-4 px-4 py-3">
+        <span className="text-sm text-fg">Minimum segment duration</span>
+        <input
+          type="number"
+          min="0"
+          value={settings.sponsorBlockMinimumDuration}
+          onChange={(event) =>
+            update.mutate({ sponsorBlockMinimumDuration: Number(event.currentTarget.value) })
+          }
+          className="w-20 rounded-lg border border-border bg-surface-strong px-2 py-1 text-right text-sm text-fg"
+        />
+      </div>
+      <ExtraToggles />
+    </>
+  );
+}

--- a/apps/web/src/settings/settings-video-preferences.tsx
+++ b/apps/web/src/settings/settings-video-preferences.tsx
@@ -1,0 +1,17 @@
+import { SettingsContentToggles } from "./settings-content-toggles";
+import { SettingsSponsorBlockPreferences } from "./settings-sponsorblock-preferences";
+
+const SECTION_LABEL = "text-xs font-medium text-fg-soft uppercase tracking-wider px-1";
+const CARD = "bg-surface rounded-xl border border-border divide-y divide-border";
+
+export function SettingsVideoPreferences() {
+  return (
+    <section className="flex flex-col gap-3">
+      <p className={SECTION_LABEL}>Content controls</p>
+      <div className={CARD}>
+        <SettingsSponsorBlockPreferences />
+        <SettingsContentToggles />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/styles/player-hotkeys.css
+++ b/apps/web/src/styles/player-hotkeys.css
@@ -1,0 +1,16 @@
+@keyframes player-rabbit-hop {
+  0%,
+  100% {
+    transform: translateY(0) rotate(-4deg);
+  }
+  38% {
+    transform: translateY(-7px) rotate(5deg);
+  }
+  62% {
+    transform: translateY(1px) rotate(-2deg);
+  }
+}
+
+.player-rabbit-hop {
+  animation: player-rabbit-hop 0.52s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
+}

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -1,4 +1,7 @@
 export type ServiceId = 0 | 5 | 6;
+export type SponsorBlockMode = "auto_skip" | "mark_only" | "disabled";
+export type SponsorBlockCategoryAction = "auto_skip" | "mark_only" | "disabled";
+type SponsorBlockCategoryActions = Record<string, SponsorBlockCategoryAction>;
 
 export type HistoryItem = {
   id: string;
@@ -68,6 +71,19 @@ export type SettingsItem = {
   defaultAudioLanguage: string;
   preferOriginalLanguage: boolean;
   enableHighQualityPlayback: boolean;
+  sponsorBlockMode: SponsorBlockMode;
+  sponsorBlockCategoryActions: SponsorBlockCategoryActions;
+  sponsorBlockMinimumDuration: number;
+  sponsorBlockShowCurrentSegment: boolean;
+  sponsorBlockShowChapters: boolean;
+  sponsorBlockShowFullVideoLabels: boolean;
+  sponsorBlockManualSkipOnFullVideo: boolean;
+  sponsorBlockSkipNonMusicOnlyOnMusicVideos: boolean;
+  sponsorBlockMuteInsteadOfSkip: boolean;
+  hideHomeRecommendations: boolean;
+  hideRelatedVideos: boolean;
+  hideComments: boolean;
+  hideShorts: boolean;
 };
 
 export type SearchHistoryItem = {


### PR DESCRIPTION
## Summary
- add hold-to-fast-forward controls for keyboard, mouse, touch, and pen input
- add content visibility settings for home recommendations, related videos, comments, danmaku, and Shorts
- add advanced SponsorBlock settings, player markers, current segment overlay, manual skip, and mute-instead-of-skip support

Issues: #55, #56, #58

## Verification
- quality checks passed
- production build passed
- SponsorBlock watch page manual validation passed
- player hotkeys and long-press manual validation passed
- content visibility settings manual validation passed