### PR TITLE
fix: apply sponsorblock global mode

### DIFF
--- a/apps/web/src/settings/settings-sponsorblock-preferences.tsx
+++ b/apps/web/src/settings/settings-sponsorblock-preferences.tsx
@@ -14,6 +14,14 @@ const MODES: { value: SponsorBlockMode; label: string; description: string }[] =
   { value: "disabled", label: "Off", description: "Ignore all SponsorBlock data." },
 ];
 
+function globalCategoryActions(action: SponsorBlockCategoryAction) {
+  const actions: Record<string, SponsorBlockCategoryAction> = {};
+  for (const category of SPONSORBLOCK_CATEGORIES) {
+    actions[category.id] = action;
+  }
+  return actions;
+}
+
 function GlobalMode() {
   const { settings, update } = useSettings();
   return (
@@ -31,7 +39,12 @@ function GlobalMode() {
             <button
               key={option.value}
               type="button"
-              onClick={() => update.mutate({ sponsorBlockMode: option.value })}
+              onClick={() =>
+                update.mutate({
+                  sponsorBlockMode: option.value,
+                  sponsorBlockCategoryActions: globalCategoryActions(option.value),
+                })
+              }
               className={`rounded-lg border px-3 py-2 text-left transition-colors ${
                 selected
                   ? "border-fg bg-surface-strong text-fg"


### PR DESCRIPTION
## Summary
- apply the selected SponsorBlock global behavior to every category rule
- keep category controls editable after choosing Skip, Mark, or Off

## Verification
- bun run check
- bun run build
- bun run knip
- bun run sherif
- git diff --check