### PR TITLE
feat: improve playlist video actions

### DIFF
--- a/apps/web/src/components/continue-card.tsx
+++ b/apps/web/src/components/continue-card.tsx
@@ -5,9 +5,11 @@ import { formatDuration } from "../lib/format";
 import { resolveHistoryChannelMeta } from "../lib/history-enrichment";
 import { proxyImage } from "../lib/proxy";
 import { watchRouteSearch } from "../lib/watch-url";
+import type { VideoStream } from "../types/stream";
 import type { HistoryItem } from "../types/user";
 import { ChannelRouteLink } from "./channel-route-link";
 import { HistoryChannelAvatar } from "./history-channel-avatar";
+import { VideoCardFeedbackMenu } from "./video-card-feedback-menu";
 import { VideoProgressBar } from "./video-progress-bar";
 import { VerifiedBadgeIcon } from "./watch-icons";
 
@@ -18,6 +20,20 @@ type ContinueCardProps = {
 export function ContinueCard({ item }: ContinueCardProps) {
   const prefetch = useWatchPrefetch(item.url);
   const [uploaderVerified, setUploaderVerified] = useState(item.uploaderVerified ?? false);
+  const thumbnail = proxyImage(item.thumbnail);
+  const menuStream: VideoStream = {
+    id: item.url,
+    title: item.title,
+    thumbnail,
+    rawThumbnail: item.thumbnail,
+    rawChannelAvatar: item.channelAvatar ?? "",
+    channelName: item.channelName,
+    channelUrl: item.channelUrl || undefined,
+    channelAvatar: proxyImage(item.channelAvatar ?? ""),
+    uploaderVerified,
+    views: 0,
+    duration: item.duration,
+  };
 
   useEffect(() => {
     let active = true;
@@ -46,7 +62,7 @@ export function ContinueCard({ item }: ContinueCardProps) {
       >
         <div className="relative aspect-video overflow-hidden rounded-lg bg-surface-strong">
           <img
-            src={proxyImage(item.thumbnail)}
+            src={thumbnail}
             alt={item.title}
             className="h-full w-full object-cover"
             loading="lazy"
@@ -62,27 +78,30 @@ export function ContinueCard({ item }: ContinueCardProps) {
         </span>
       </Link>
       <div className="mt-1.5 flex min-w-0 items-center gap-1.5">
-        {item.channelUrl ? (
-          <ChannelRouteLink url={item.channelUrl} className="flex-shrink-0">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          {item.channelUrl ? (
+            <ChannelRouteLink url={item.channelUrl} className="flex-shrink-0">
+              <HistoryChannelAvatar item={item} className="h-5 w-5" />
+            </ChannelRouteLink>
+          ) : (
             <HistoryChannelAvatar item={item} className="h-5 w-5" />
-          </ChannelRouteLink>
-        ) : (
-          <HistoryChannelAvatar item={item} className="h-5 w-5" />
-        )}
-        {item.channelUrl ? (
-          <ChannelRouteLink
-            url={item.channelUrl}
-            className="flex min-w-0 items-center gap-1 text-[10px] text-fg-soft transition-colors hover:text-fg"
-          >
-            <span className="min-w-0 truncate">{item.channelName}</span>
-            {uploaderVerified && <VerifiedBadgeIcon />}
-          </ChannelRouteLink>
-        ) : (
-          <span className="flex min-w-0 items-center gap-1 text-[10px] text-fg-soft">
-            <span className="min-w-0 truncate">{item.channelName}</span>
-            {uploaderVerified && <VerifiedBadgeIcon />}
-          </span>
-        )}
+          )}
+          {item.channelUrl ? (
+            <ChannelRouteLink
+              url={item.channelUrl}
+              className="flex min-w-0 items-center gap-1 text-[10px] text-fg-soft transition-colors hover:text-fg"
+            >
+              <span className="min-w-0 truncate">{item.channelName}</span>
+              {uploaderVerified && <VerifiedBadgeIcon />}
+            </ChannelRouteLink>
+          ) : (
+            <span className="flex min-w-0 items-center gap-1 text-[10px] text-fg-soft">
+              <span className="min-w-0 truncate">{item.channelName}</span>
+              {uploaderVerified && <VerifiedBadgeIcon />}
+            </span>
+          )}
+        </div>
+        <VideoCardFeedbackMenu stream={menuStream} />
       </div>
     </div>
   );

--- a/apps/web/src/components/continue-watching.tsx
+++ b/apps/web/src/components/continue-watching.tsx
@@ -1,16 +1,13 @@
 import { useHistory } from "../hooks/use-history";
+import { isVideoInProgress } from "../lib/watch-progress";
 import { ContinueCard } from "./continue-card";
 
 const MAX_ITEMS = 12;
 
-function isInProgress(progress: number, duration: number): boolean {
-  return progress > 0 && duration > 0 && progress < duration * 0.9;
-}
-
 export function ContinueWatching() {
   const { items } = useHistory();
   const displayed = items
-    .filter((h) => isInProgress(h.progress, h.duration))
+    .filter((h) => isVideoInProgress(h.progress, h.duration))
     .sort((a, b) => b.watchedAt - a.watchedAt)
     .slice(0, MAX_ITEMS);
 

--- a/apps/web/src/components/history-card.tsx
+++ b/apps/web/src/components/history-card.tsx
@@ -2,11 +2,13 @@ import { Link } from "@tanstack/react-router";
 import { useWatchPrefetch } from "../hooks/use-watch-prefetch";
 import { formatDuration } from "../lib/format";
 import { proxyImage } from "../lib/proxy";
+import { isVideoWatched } from "../lib/watch-progress";
 import { watchRouteSearch } from "../lib/watch-url";
 import type { HistoryItem } from "../types/user";
 import { ChannelRouteLink } from "./channel-route-link";
 import { HistoryChannelAvatar } from "./history-channel-avatar";
 import { VideoProgressBar } from "./video-progress-bar";
+import { WatchedBadge } from "./watched-badge";
 
 function XIcon() {
   return (
@@ -44,6 +46,7 @@ function formatWatchedAt(timestamp: number): string {
 export function HistoryCard({ item, onRemove, index }: HistoryCardProps) {
   const delay = Math.min(index * 45, 270);
   const prefetch = useWatchPrefetch(item.url);
+  const watched = isVideoWatched(item.progress, item.duration);
 
   return (
     <div
@@ -68,6 +71,11 @@ export function HistoryCard({ item, onRemove, index }: HistoryCardProps) {
           {item.duration > 0 && (
             <span className="absolute bottom-1.5 right-1.5 bg-black/80 text-white text-xs px-1 rounded">
               {formatDuration(item.duration)}
+            </span>
+          )}
+          {watched && (
+            <span className="absolute top-2 left-2">
+              <WatchedBadge />
             </span>
           )}
           <VideoProgressBar progress={item.progress} duration={item.duration} alwaysVisible />

--- a/apps/web/src/components/playlist-video-row.tsx
+++ b/apps/web/src/components/playlist-video-row.tsx
@@ -1,7 +1,10 @@
 import { Link } from "@tanstack/react-router";
 import { useWatchPrefetch } from "../hooks/use-watch-prefetch";
+import { isVideoWatched } from "../lib/watch-progress";
 import { watchRouteSearch } from "../lib/watch-url";
 import type { PlaylistVideoItem } from "../types/user";
+import { VideoProgressBar } from "./video-progress-bar";
+import { WatchedBadge } from "./watched-badge";
 
 function XIcon() {
   return (
@@ -29,6 +32,7 @@ type Props = { video: PlaylistVideoItem; onRemove: () => void };
 export function PlaylistVideoRow({ video, onRemove }: Props) {
   const prefetch = useWatchPrefetch(video.url);
   const thumbnail = video.thumbnail.trim().length > 0 ? video.thumbnail : null;
+  const watched = video.watched || isVideoWatched(video.watchPosition, video.duration);
 
   return (
     <div className="flex flex-col gap-2 group relative">
@@ -49,6 +53,12 @@ export function PlaylistVideoRow({ video, onRemove }: Props) {
               decoding="async"
             />
           )}
+          {watched && (
+            <span className="absolute top-2 left-2">
+              <WatchedBadge />
+            </span>
+          )}
+          <VideoProgressBar progress={video.watchPosition} duration={video.duration} />
           <button
             type="button"
             onClick={(e) => {

--- a/apps/web/src/components/related-card.tsx
+++ b/apps/web/src/components/related-card.tsx
@@ -5,6 +5,7 @@ import { watchRouteSearch } from "../lib/watch-url";
 import type { VideoStream } from "../types/stream";
 import { ChannelAvatar } from "./channel-avatar";
 import { ChannelRouteLink } from "./channel-route-link";
+import { VideoCardFeedbackMenu } from "./video-card-feedback-menu";
 import { VideoStatusBadge } from "./video-status-badge";
 import { VerifiedBadgeIcon } from "./watch-icons";
 
@@ -87,6 +88,7 @@ export function RelatedCard({ stream }: Props) {
         )}
         <p className="text-xs text-fg-soft">{formatViews(stream.views)}</p>
       </div>
+      <VideoCardFeedbackMenu stream={stream} />
     </div>
   );
 }

--- a/apps/web/src/components/share-dropdown.tsx
+++ b/apps/web/src/components/share-dropdown.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { formatTimecode, parseTimecode } from "../lib/timecode";
+import { toPublicWatchUrl } from "../lib/watch-url";
+
+const MARGIN = 8;
+
+type Props = {
+  sourceUrl: string;
+  anchorEl: HTMLElement | null;
+  currentPositionMs: number;
+  onClose: () => void;
+  onShare: (url: string) => void;
+};
+
+export function ShareDropdown({ sourceUrl, anchorEl, currentPositionMs, onClose, onShare }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const anchorElRef = useRef(anchorEl);
+  const onCloseRef = useRef(onClose);
+  const currentSeconds = Math.max(0, Math.floor(currentPositionMs / 1000));
+  const [timecode, setTimecode] = useState(() => formatTimecode(currentSeconds));
+  const [panelStyle, setPanelStyle] = useState<React.CSSProperties>({ visibility: "hidden" });
+  anchorElRef.current = anchorEl;
+  onCloseRef.current = onClose;
+
+  useLayoutEffect(() => {
+    if (!anchorEl || !panelRef.current) return;
+    const anchor = anchorEl.getBoundingClientRect();
+    const panel = panelRef.current.getBoundingClientRect();
+    const vw = document.documentElement.clientWidth;
+    const left = Math.max(MARGIN, Math.min(anchor.left, vw - panel.width - MARGIN));
+    const top = Math.max(MARGIN, anchor.bottom + MARGIN);
+    setPanelStyle({ position: "fixed", top, left, visibility: "visible" });
+  }, [anchorEl]);
+
+  useEffect(() => {
+    function onMouseDown(event: MouseEvent) {
+      const target = event.target as Node;
+      const outsidePanel = panelRef.current && !panelRef.current.contains(target);
+      const outsideAnchor = !anchorElRef.current?.contains(target);
+      if (outsidePanel && outsideAnchor) onCloseRef.current();
+    }
+    window.addEventListener("mousedown", onMouseDown);
+    return () => window.removeEventListener("mousedown", onMouseDown);
+  }, []);
+
+  function sharePlain() {
+    onShare(toPublicWatchUrl(sourceUrl, window.location.origin));
+    onClose();
+  }
+
+  function shareTimecode() {
+    const seconds = parseTimecode(timecode);
+    onShare(toPublicWatchUrl(sourceUrl, window.location.origin, seconds ?? currentSeconds));
+    onClose();
+  }
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      style={panelStyle}
+      className="fixed z-50 w-56 overflow-hidden rounded-lg border border-border-strong bg-surface shadow-2xl"
+    >
+      <button
+        type="button"
+        onClick={sharePlain}
+        className="w-full px-3 py-2 text-left text-sm text-fg transition-colors hover:bg-surface-strong"
+      >
+        Copy link
+      </button>
+      <div className="border-t border-border px-3 py-2">
+        <label className="mb-2 block text-xs text-fg-soft" htmlFor="share-timecode">
+          Copy from time
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="share-timecode"
+            type="text"
+            value={timecode}
+            onChange={(event) => setTimecode(event.currentTarget.value)}
+            className="min-w-0 flex-1 border-border-strong border-b bg-transparent px-0 py-1 text-sm text-fg outline-none focus:border-fg"
+          />
+          <button
+            type="button"
+            onClick={shareTimecode}
+            className="text-xs font-semibold text-fg hover:text-white"
+          >
+            Copy
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/video-block-actions-dropdown.tsx
+++ b/apps/web/src/components/video-block-actions-dropdown.tsx
@@ -6,6 +6,7 @@ const MARGIN = 8;
 type Props = {
   anchorEl: HTMLElement | null;
   onClose: () => void;
+  onSaveToPlaylist?: () => void;
   onToggleVideoBlock?: () => void;
   onToggleChannelBlock?: () => void;
   videoBlocked?: boolean;
@@ -15,6 +16,7 @@ type Props = {
 export function VideoBlockActionsDropdown({
   anchorEl,
   onClose,
+  onSaveToPlaylist,
   onToggleVideoBlock,
   onToggleChannelBlock,
   videoBlocked,
@@ -66,6 +68,15 @@ export function VideoBlockActionsDropdown({
       style={panelStyle}
       className="fixed z-50 w-56 overflow-hidden rounded-lg border border-border-strong bg-surface shadow-2xl"
     >
+      {onSaveToPlaylist && (
+        <button
+          type="button"
+          onClick={onSaveToPlaylist}
+          className="w-full px-3 py-2 text-left text-sm text-fg transition-colors hover:bg-surface-strong"
+        >
+          Save to playlist
+        </button>
+      )}
       {onToggleVideoBlock && (
         <button
           type="button"

--- a/apps/web/src/components/video-card-feedback-panel.tsx
+++ b/apps/web/src/components/video-card-feedback-panel.tsx
@@ -1,7 +1,10 @@
+import { useState } from "react";
 import { useAuth } from "../hooks/use-auth";
 import { useBlocked } from "../hooks/use-blocked";
 import { goto } from "../lib/route-redirect";
 import type { VideoStream } from "../types/stream";
+import { PlaylistAddDropdown } from "./playlist-add-dropdown";
+import { Toast } from "./toast";
 import { VideoBlockActionsDropdown } from "./video-block-actions-dropdown";
 
 type Props = {
@@ -12,6 +15,8 @@ type Props = {
 
 export function VideoCardFeedbackPanel({ stream, anchorEl, onClose }: Props) {
   const { isAuthed } = useAuth();
+  const [playlistOpen, setPlaylistOpen] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
   const { channels, videos, addChannel, removeChannel, addVideo, removeVideo } = useBlocked();
   const channelBlocked =
     !!stream.channelUrl &&
@@ -47,14 +52,37 @@ export function VideoCardFeedbackPanel({ stream, anchorEl, onClose }: Props) {
     });
   }
 
+  function openPlaylist() {
+    if (requireAuth()) return;
+    setPlaylistOpen(true);
+  }
+
+  function handleSaved(label: string) {
+    setToast(label);
+    setTimeout(() => setToast(null), 2000);
+  }
+
   return (
-    <VideoBlockActionsDropdown
-      anchorEl={anchorEl}
-      onClose={onClose}
-      onToggleVideoBlock={toggleVideoBlock}
-      onToggleChannelBlock={stream.channelUrl ? toggleChannelBlock : undefined}
-      videoBlocked={videoBlocked}
-      channelBlocked={channelBlocked}
-    />
+    <>
+      {playlistOpen ? (
+        <PlaylistAddDropdown
+          stream={stream}
+          anchorEl={anchorEl}
+          onClose={onClose}
+          onSaved={handleSaved}
+        />
+      ) : (
+        <VideoBlockActionsDropdown
+          anchorEl={anchorEl}
+          onClose={onClose}
+          onSaveToPlaylist={openPlaylist}
+          onToggleVideoBlock={toggleVideoBlock}
+          onToggleChannelBlock={stream.channelUrl ? toggleChannelBlock : undefined}
+          videoBlocked={videoBlocked}
+          channelBlocked={channelBlocked}
+        />
+      )}
+      <Toast message={toast} />
+    </>
   );
 }

--- a/apps/web/src/components/video-player.tsx
+++ b/apps/web/src/components/video-player.tsx
@@ -111,7 +111,7 @@ export function VideoPlayer({
       <DefaultVideoLayout
         icons={defaultLayoutIcons}
         thumbnails={thumbnailVtt}
-        smallLayoutWhen={false}
+        smallLayoutWhen
         translations={{ Captions: "Subtitles" }}
         slots={{
           settingsMenuItemsStart: (

--- a/apps/web/src/components/watch-actions.tsx
+++ b/apps/web/src/components/watch-actions.tsx
@@ -4,12 +4,12 @@ import { useFavoritesPlaylist } from "../hooks/use-favorites-playlist";
 import { useShareUrl } from "../hooks/use-share-url";
 import { detectProvider } from "../lib/provider";
 import { goto } from "../lib/route-redirect";
-import { toPublicWatchUrl } from "../lib/watch-url";
 import type { VideoStream } from "../types/stream";
 import { DanmakuControls } from "./danmaku-controls";
 import { DownloadSheet } from "./download-sheet";
 import { PlaylistAddDropdown } from "./playlist-add-dropdown";
 import { ReportBugModal } from "./report-bug-modal";
+import { ShareDropdown } from "./share-dropdown";
 import { Toast } from "./toast";
 import { WatchActionButton } from "./watch-action-button";
 import { BugIcon, DownloadIcon, ListPlusIcon, ShareIcon, StarIcon } from "./watch-icons";
@@ -17,14 +17,17 @@ import { WatchMoreActions } from "./watch-more-actions";
 
 type Props = {
   stream: VideoStream;
+  currentPositionRef?: { current: number };
 };
-export function WatchActions({ stream }: Props) {
+export function WatchActions({ stream, currentPositionRef }: Props) {
   const { copied, share } = useShareUrl();
   const [playlistOpen, setPlaylistOpen] = useState(false);
   const [downloadOpen, setDownloadOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
   const [toastLabel, setToastLabel] = useState<string | null>(null);
   const saveAnchorRef = useRef<HTMLButtonElement>(null);
+  const shareAnchorRef = useRef<HTMLButtonElement>(null);
   const { isAuthed } = useAuth();
   const {
     add: addFavorite,
@@ -81,10 +84,15 @@ export function WatchActions({ stream }: Props) {
         <DownloadIcon />
         Download
       </WatchActionButton>
-      <WatchActionButton onClick={() => share(toPublicWatchUrl(stream.id, window.location.origin))}>
+      <button
+        ref={shareAnchorRef}
+        type="button"
+        onClick={() => setShareOpen((open) => !open)}
+        className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-colors text-fg-muted hover:text-fg hover:bg-surface-strong"
+      >
         <ShareIcon />
         Share
-      </WatchActionButton>
+      </button>
       <Toast message={copied ? "Link copied to clipboard" : toastLabel} />
       {showSave && (
         <button
@@ -121,6 +129,15 @@ export function WatchActions({ stream }: Props) {
           anchorEl={saveAnchorRef.current}
           onClose={() => setPlaylistOpen(false)}
           onSaved={handleSaved}
+        />
+      )}
+      {shareOpen && (
+        <ShareDropdown
+          sourceUrl={stream.id}
+          anchorEl={shareAnchorRef.current}
+          currentPositionMs={currentPositionRef?.current ?? 0}
+          onClose={() => setShareOpen(false)}
+          onShare={(url) => void share(url)}
         />
       )}
       {downloadOpen && (

--- a/apps/web/src/components/watch-layout.tsx
+++ b/apps/web/src/components/watch-layout.tsx
@@ -112,13 +112,12 @@ export function WatchLayout({ stream, startTime }: Props) {
     />
   );
 
-  const { containerClass, playerWrapClass, playerBoxClass, playerClassName, mediaClassName } =
-    getWatchLayoutClasses(cinemaMode);
+  const layoutClasses = getWatchLayoutClasses(cinemaMode);
 
   return (
-    <div className={containerClass}>
-      <div className={playerWrapClass}>
-        <div className={playerBoxClass}>
+    <div className={layoutClasses.containerClass}>
+      <div className={layoutClasses.playerWrapClass}>
+        <div className={layoutClasses.playerBoxClass}>
           {settingsReady ? (
             <>
               <VideoPlayer
@@ -150,8 +149,8 @@ export function WatchLayout({ stream, startTime }: Props) {
                 onError={handlePlayerError}
                 onEnded={playerEvents.handleEnded}
                 onSeekReady={(s) => (seekRef.current = s)}
-                className={playerClassName}
-                mediaClassName={mediaClassName}
+                className={layoutClasses.playerClassName}
+                mediaClassName={layoutClasses.mediaClassName}
               />
               {playerFailed && <PlayerError onRetry={reset} />}
             </>
@@ -163,6 +162,7 @@ export function WatchLayout({ stream, startTime }: Props) {
           <WatchMeta
             stream={stream}
             showComments={!hideComments}
+            currentPositionRef={playerEvents.positionRef}
             onSeekTimestamp={(s) => seekRef.current?.(s)}
           />
         )}

--- a/apps/web/src/components/watch-meta.tsx
+++ b/apps/web/src/components/watch-meta.tsx
@@ -7,14 +7,20 @@ import { WatchInfo } from "./watch-info";
 type Props = {
   stream: VideoStream;
   showComments?: boolean;
+  currentPositionRef?: { current: number };
   onSeekTimestamp?: (seconds: number) => void;
 };
 
-export function WatchMeta({ stream, showComments = true, onSeekTimestamp }: Props) {
+export function WatchMeta({
+  stream,
+  showComments = true,
+  currentPositionRef,
+  onSeekTimestamp,
+}: Props) {
   return (
     <>
       <WatchInfo stream={stream} />
-      <WatchActions stream={stream} />
+      <WatchActions stream={stream} currentPositionRef={currentPositionRef} />
       {stream.description && (
         <WatchDescription description={stream.description} onSeekTimestamp={onSeekTimestamp} />
       )}

--- a/apps/web/src/components/watched-badge.tsx
+++ b/apps/web/src/components/watched-badge.tsx
@@ -1,0 +1,30 @@
+function CheckIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={12}
+      height={12}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={3}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="Watched"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+export function WatchedBadge() {
+  return (
+    <span
+      className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-black/80 text-white ring-1 ring-white/25 backdrop-blur"
+      title="Watched"
+    >
+      <CheckIcon />
+    </span>
+  );
+}

--- a/apps/web/src/hooks/use-playlists.ts
+++ b/apps/web/src/hooks/use-playlists.ts
@@ -18,7 +18,7 @@ type RenamePayload = { id: string; name: string; description?: string };
 
 type AddVideoPayload = {
   playlistId: string;
-  video: Omit<PlaylistVideoItem, "id" | "position">;
+  video: Pick<PlaylistVideoItem, "url" | "title" | "thumbnail" | "duration">;
 };
 
 type RemoveVideoPayload = {
@@ -66,7 +66,20 @@ export function usePlaylists() {
       qc.setQueryData<PlaylistItem[]>(KEY, (old) =>
         (old ?? []).map((p) =>
           p.id === playlistId
-            ? { ...p, videos: [...p.videos, { id: "", position: p.videos.length, ...video }] }
+            ? {
+                ...p,
+                videos: [
+                  ...p.videos,
+                  {
+                    id: "",
+                    position: p.videos.length,
+                    watchPosition: 0,
+                    watched: false,
+                    progressUpdatedAt: 0,
+                    ...video,
+                  },
+                ],
+              }
             : p,
         ),
       );

--- a/apps/web/src/lib/search-overlay-query.ts
+++ b/apps/web/src/lib/search-overlay-query.ts
@@ -4,11 +4,6 @@ function canUseStorage(): boolean {
   return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
 }
 
-function readSearchOverlayQuery(): string {
-  if (!canUseStorage()) return "";
-  return window.localStorage.getItem(KEY) ?? "";
-}
-
 export function writeSearchOverlayQuery(value: string): void {
   if (!canUseStorage()) return;
   const trimmed = value.trim();
@@ -24,5 +19,5 @@ export function resolveInitialSearchOverlayQuery(pathname: string, searchStr: st
     const q = new URLSearchParams(searchStr).get("q") ?? "";
     if (q.trim().length > 0) return q.trim();
   }
-  return readSearchOverlayQuery();
+  return "";
 }

--- a/apps/web/src/lib/timecode.ts
+++ b/apps/web/src/lib/timecode.ts
@@ -1,0 +1,22 @@
+export function formatTimecode(seconds: number): string {
+  const safe = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safe / 3600);
+  const minutes = Math.floor((safe % 3600) / 60);
+  const remainingSeconds = safe % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(remainingSeconds).padStart(2, "0")}`;
+  }
+  return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`;
+}
+
+export function parseTimecode(value: string): number | null {
+  const parts = value
+    .trim()
+    .split(":")
+    .map((part) => Number(part));
+  if (parts.length === 0 || parts.length > 3) return null;
+  if (parts.some((part) => !Number.isFinite(part) || part < 0)) return null;
+  if (parts.length === 1) return Math.floor(parts[0] ?? 0);
+  if (parts.length === 2) return Math.floor((parts[0] ?? 0) * 60 + (parts[1] ?? 0));
+  return Math.floor((parts[0] ?? 0) * 3600 + (parts[1] ?? 0) * 60 + (parts[2] ?? 0));
+}

--- a/apps/web/src/lib/watch-progress.ts
+++ b/apps/web/src/lib/watch-progress.ts
@@ -1,0 +1,11 @@
+export function isVideoWatched(progress: number, duration: number): boolean {
+  if (!Number.isFinite(progress) || !Number.isFinite(duration)) return false;
+  if (progress <= 0 || duration <= 0) return false;
+  const boundedProgress = Math.min(progress, duration);
+  if (duration > 60) return boundedProgress >= duration - 60;
+  return boundedProgress >= duration * 0.9;
+}
+
+export function isVideoInProgress(progress: number, duration: number): boolean {
+  return progress > 0 && duration > 0 && !isVideoWatched(progress, duration);
+}

--- a/apps/web/src/lib/watch-url.ts
+++ b/apps/web/src/lib/watch-url.ts
@@ -2,6 +2,7 @@ const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
 
 type WatchRouteSearch = {
   v: string;
+  t?: number;
 };
 
 function hostMatches(host: string, domain: string): boolean {
@@ -44,8 +45,11 @@ export function watchRouteSearch(sourceUrl: string): WatchRouteSearch {
   return { v: toPublicWatchParam(sourceUrl) };
 }
 
-export function toPublicWatchUrl(sourceUrl: string, origin: string): string {
+export function toPublicWatchUrl(sourceUrl: string, origin: string, startSeconds?: number): string {
   const url = new URL("/watch", origin);
   url.searchParams.set("v", toPublicWatchParam(sourceUrl));
+  if (typeof startSeconds === "number" && Number.isFinite(startSeconds) && startSeconds > 0) {
+    url.searchParams.set("t", String(Math.floor(startSeconds)));
+  }
   return url.toString();
 }

--- a/apps/web/src/routes/watch.tsx
+++ b/apps/web/src/routes/watch.tsx
@@ -33,7 +33,7 @@ function PlayerOnlyLoader() {
 }
 
 function WatchPage() {
-  const { v } = Route.useSearch();
+  const { v, t } = Route.useSearch();
   const navigate = useNavigate({ from: "/watch" });
   const sourceUrl = toWatchSourceUrl(v);
   const publicParam = toPublicWatchParam(sourceUrl);
@@ -107,7 +107,13 @@ function WatchPage() {
   const serverPositionMs = (stream.startPosition ?? 0) * 1000;
   const resumeMs = savedPosition > 0 ? savedPosition : serverPositionMs;
   const durationMs = stream.duration * 1000;
-  const startTime = resumeMs >= 5000 && resumeMs < durationMs * 0.95 ? resumeMs : 0;
+  const sharedTimeMs = t && t > 0 ? t * 1000 : 0;
+  const startTime =
+    sharedTimeMs > 0 && sharedTimeMs < durationMs
+      ? sharedTimeMs
+      : resumeMs >= 5000 && resumeMs < durationMs * 0.95
+        ? resumeMs
+        : 0;
 
   return (
     <Suspense fallback={<PlayerOnlyLoader />}>
@@ -117,8 +123,13 @@ function WatchPage() {
 }
 
 export const Route = createFileRoute("/watch")({
-  validateSearch: (search: Record<string, unknown>) => ({
-    v: typeof search.v === "string" ? search.v.trim() : "",
-  }),
+  validateSearch: (search: Record<string, unknown>) => {
+    const rawTime =
+      typeof search.t === "string" || typeof search.t === "number" ? Number(search.t) : 0;
+    return {
+      v: typeof search.v === "string" ? search.v.trim() : "",
+      t: Number.isFinite(rawTime) && rawTime > 0 ? Math.floor(rawTime) : undefined,
+    };
+  },
   component: WatchPage,
 });

--- a/apps/web/src/routes/watch.tsx
+++ b/apps/web/src/routes/watch.tsx
@@ -126,9 +126,11 @@ export const Route = createFileRoute("/watch")({
   validateSearch: (search: Record<string, unknown>) => {
     const rawTime =
       typeof search.t === "string" || typeof search.t === "number" ? Number(search.t) : 0;
+    const v = typeof search.v === "string" ? search.v.trim() : "";
+    if (!Number.isFinite(rawTime) || rawTime <= 0) return { v };
     return {
-      v: typeof search.v === "string" ? search.v.trim() : "",
-      t: Number.isFinite(rawTime) && rawTime > 0 ? Math.floor(rawTime) : undefined,
+      v,
+      t: Math.floor(rawTime),
     };
   },
   component: WatchPage,

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -31,6 +31,9 @@ export type PlaylistVideoItem = {
   thumbnail: string;
   duration: number;
   position: number;
+  watchPosition: number;
+  watched: boolean;
+  progressUpdatedAt: number;
 };
 
 export type PlaylistItem = {


### PR DESCRIPTION
## Summary
- add Save to playlist to video card menus, including related and continue watching cards
- show playlist/history watched progress using the backend playlist progress fields
- clear the mobile search overlay when opened outside search results
- add share links with editable timecodes and support watch `t` links
- keep fullscreen controls visible on mobile with the compact player layout

Issues: #67, #68

## Verification
- bun run check
- bun run build
- bun run knip
- bun run sherif
- git diff --check
- dev CI passed
- dev Docker build passed