### PR TITLE
feat: public playlists, mobile tab bar, and preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 AGENTS.md
+CLAUDE.md
 Vision.md
 response.md
 attente.md
@@ -7,6 +8,7 @@ question.md
 node_modules/
 dist/
 build/
+tmp/
 .DS_Store
 *.tsbuildinfo
 .env

--- a/apps/web/src/components/channel-filter-bar.tsx
+++ b/apps/web/src/components/channel-filter-bar.tsx
@@ -1,30 +1,32 @@
 import type { FormEvent } from "react";
 import { useEffect, useState } from "react";
 import type { ChannelSort } from "../lib/api";
+import type { ChannelTab } from "../lib/channel-route-url";
 import { CHANNEL_SORT_OPTIONS, channelSortOrDefault } from "../lib/channel-sort";
 
-const CHANNEL_TABS = [
-  { live: false, label: "Videos" },
-  { live: true, label: "Live" },
+const CHANNEL_TABS: { tab: ChannelTab; label: string }[] = [
+  { tab: "videos", label: "Videos" },
+  { tab: "live", label: "Live" },
+  { tab: "playlists", label: "Playlists" },
 ];
 
 type Props = {
   sort: ChannelSort;
   query: string;
-  live: boolean;
+  tab: ChannelTab;
   searchAvailable: boolean;
   onSearch: (query: string) => void;
-  onLiveChange: (live: boolean) => void;
+  onTabChange: (tab: ChannelTab) => void;
   onSortChange: (sort: ChannelSort) => void;
 };
 
 export function ChannelFilterBar({
   sort,
   query,
-  live,
+  tab,
   searchAvailable,
   onSearch,
-  onLiveChange,
+  onTabChange,
   onSortChange,
 }: Props) {
   const [input, setInput] = useState(query);
@@ -50,23 +52,23 @@ export function ChannelFilterBar({
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         {searchAvailable && (
           <div className="flex w-fit items-center gap-2 text-sm">
-            {CHANNEL_TABS.map((tab) => (
+            {CHANNEL_TABS.map((item) => (
               <button
-                key={tab.label}
+                key={item.tab}
                 type="button"
-                onClick={() => onLiveChange(tab.live)}
+                onClick={() => onTabChange(item.tab)}
                 className={`border-border-strong border-b py-1 font-medium transition-colors ${
-                  live === tab.live
+                  tab === item.tab
                     ? "border-fg text-fg"
                     : "border-transparent text-fg-soft hover:text-fg"
                 }`}
               >
-                {tab.label}
+                {item.label}
               </button>
             ))}
           </div>
         )}
-        {searchAvailable && (
+        {searchAvailable && tab === "videos" && (
           <div className="min-w-0 flex-1 md:max-w-lg">
             <form onSubmit={submitSearch} className="flex min-w-0 items-end gap-3">
               <span className="hidden pb-2 text-xs uppercase tracking-wide text-fg-soft sm:inline">
@@ -98,7 +100,7 @@ export function ChannelFilterBar({
             </form>
           </div>
         )}
-        {!isSearching && (
+        {!isSearching && tab === "videos" && (
           <div className="flex w-fit items-center gap-2 text-sm">
             {CHANNEL_SORT_OPTIONS.map((option) => {
               const selected = option.value === sort;

--- a/apps/web/src/components/channel-page-content.tsx
+++ b/apps/web/src/components/channel-page-content.tsx
@@ -3,10 +3,12 @@ import { useChannel } from "../hooks/use-channel";
 import { useDocumentTitle } from "../hooks/use-document-title";
 import { useSubscriptions } from "../hooks/use-subscriptions";
 import { ApiError, type ChannelSort } from "../lib/api";
+import type { ChannelTab } from "../lib/channel-route-url";
 import { formatViews } from "../lib/format";
 import { detectProvider } from "../lib/provider";
 import { ChannelAvatar } from "./channel-avatar";
 import { ChannelFilterBar } from "./channel-filter-bar";
+import { ChannelPlaylistsSection } from "./channel-playlists-section";
 import { ChannelPodcastsSection } from "./channel-podcasts-section";
 import { PageSpinner } from "./page-spinner";
 import { ScrollSentinel } from "./scroll-sentinel";
@@ -18,11 +20,12 @@ type Props = {
   sourceUrl: string;
   sort: ChannelSort;
   searchQuery: string;
-  live: boolean;
-  onNavigate: (sort: ChannelSort, query: string, live: boolean) => void;
+  tab: ChannelTab;
+  onNavigate: (sort: ChannelSort, query: string, tab: ChannelTab) => void;
 };
 
-export function ChannelPageContent({ sourceUrl, sort, searchQuery, live, onNavigate }: Props) {
+export function ChannelPageContent({ sourceUrl, sort, searchQuery, tab, onNavigate }: Props) {
+  const live = tab === "live";
   const {
     meta,
     videos,
@@ -55,15 +58,15 @@ export function ChannelPageContent({ sourceUrl, sort, searchQuery, live, onNavig
   }
 
   function selectSort(nextSort: ChannelSort) {
-    onNavigate(nextSort, searchQuery, live);
+    onNavigate(nextSort, searchQuery, tab);
   }
 
   function searchChannel(nextQuery: string) {
-    onNavigate(sort, searchAvailable && !live ? nextQuery : "", live);
+    onNavigate(sort, searchAvailable && tab === "videos" ? nextQuery : "", tab);
   }
 
-  function selectLive(nextLive: boolean) {
-    onNavigate(sort, "", searchAvailable && nextLive);
+  function selectTab(nextTab: ChannelTab) {
+    onNavigate(sort, "", nextTab);
   }
 
   if (isInitialLoading) return <PageSpinner />;
@@ -118,36 +121,44 @@ export function ChannelPageContent({ sourceUrl, sort, searchQuery, live, onNavig
           </div>
         </div>
       )}
-      <ChannelPodcastsSection channelUrl={sourceUrl} channelAvatar={meta?.avatarUrl} />
+      {tab === "videos" && (
+        <ChannelPodcastsSection channelUrl={sourceUrl} channelAvatar={meta?.avatarUrl} />
+      )}
       <ChannelFilterBar
         sort={sort}
         query={searchQuery}
-        live={live}
+        tab={tab}
         searchAvailable={searchAvailable}
         onSearch={searchChannel}
-        onLiveChange={selectLive}
+        onTabChange={selectTab}
         onSortChange={selectSort}
       />
-      {isReplacingVideos ? (
-        <VideoGridSkeleton idPrefix="channel-replace" />
+      {tab === "playlists" ? (
+        <ChannelPlaylistsSection channelUrl={sourceUrl} />
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-4 gap-y-8">
-          {visibleVideos.map((v, index) => (
-            <div
-              key={v.id}
-              className="animate-card-pop-in"
-              style={{ animationDelay: `${Math.min(index * 45, 270)}ms` }}
-            >
-              <VideoCard stream={v} />
+        <>
+          {isReplacingVideos ? (
+            <VideoGridSkeleton idPrefix="channel-replace" />
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-4 gap-y-8">
+              {visibleVideos.map((v, index) => (
+                <div
+                  key={v.id}
+                  className="animate-card-pop-in"
+                  style={{ animationDelay: `${Math.min(index * 45, 270)}ms` }}
+                >
+                  <VideoCard stream={v} />
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          )}
+          {isFetchingNextPage && <VideoGridSkeleton idPrefix="channel-next" />}
+          <ScrollSentinel
+            onIntersect={fetchNextPage}
+            enabled={hasNextPage && !isFetchingNextPage && !isReplacingVideos}
+          />
+        </>
       )}
-      {isFetchingNextPage && <VideoGridSkeleton idPrefix="channel-next" />}
-      <ScrollSentinel
-        onIntersect={fetchNextPage}
-        enabled={hasNextPage && !isFetchingNextPage && !isReplacingVideos}
-      />
     </div>
   );
 }

--- a/apps/web/src/components/channel-playlists-section.tsx
+++ b/apps/web/src/components/channel-playlists-section.tsx
@@ -1,0 +1,32 @@
+import { useChannelPlaylists } from "../hooks/use-channel-playlists";
+import { PageSpinner } from "./page-spinner";
+import { PublicPlaylistCard } from "./public-playlist-card";
+import { ScrollSentinel } from "./scroll-sentinel";
+
+type Props = {
+  channelUrl: string;
+};
+
+export function ChannelPlaylistsSection({ channelUrl }: Props) {
+  const { data, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
+    useChannelPlaylists(channelUrl);
+  const playlists = (data?.pages.flatMap((p) => p.playlists) ?? []).filter(
+    (pl, i, arr) => arr.findIndex((x) => x.url === pl.url) === i,
+  );
+
+  if (isLoading) return <PageSpinner />;
+  if (playlists.length === 0) {
+    return <p className="text-fg-muted text-sm">No playlists on this channel.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+        {playlists.map((pl) => (
+          <PublicPlaylistCard key={pl.url} playlist={pl} />
+        ))}
+      </div>
+      <ScrollSentinel onIntersect={fetchNextPage} enabled={hasNextPage && !isFetchingNextPage} />
+    </div>
+  );
+}

--- a/apps/web/src/components/mobile-tab-bar.tsx
+++ b/apps/web/src/components/mobile-tab-bar.tsx
@@ -38,7 +38,7 @@ export function MobileTabBar() {
   return (
     <nav
       aria-label="Primary"
-      className="fixed bottom-0 left-0 right-0 z-30 flex items-stretch border-t border-border bg-app/95 backdrop-blur pb-[env(safe-area-inset-bottom)]"
+      className="fixed bottom-0 left-0 right-0 z-30 flex items-stretch border-t border-border bg-app pb-[env(safe-area-inset-bottom)]"
     >
       {items.map((item) => (
         <Link

--- a/apps/web/src/components/mobile-tab-bar.tsx
+++ b/apps/web/src/components/mobile-tab-bar.tsx
@@ -1,0 +1,68 @@
+import { Link } from "@tanstack/react-router";
+import { Menu } from "lucide-react";
+import { useUiStore } from "../stores/ui-store";
+import { NAV_ITEMS } from "./nav-items";
+
+const BOTTOM_NAV_PATHS = ["/", "/subscriptions", "/history", "/playlists"];
+const ITEM =
+  "flex h-14 flex-1 flex-col items-center justify-center gap-0.5 text-[10px] font-medium transition-colors";
+const ACTIVE = "text-fg";
+const INACTIVE = "text-fg-muted";
+
+function TabIcon({ children, label }: { children: React.ReactNode; label: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="flex-shrink-0"
+      role="img"
+      aria-label={label}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function MobileTabBar() {
+  const openMobileSidebar = useUiStore((s) => s.openMobileSidebar);
+  const mobileOpen = useUiStore((s) => s.mobileSidebarOpen);
+  const items = NAV_ITEMS.filter((item) => BOTTOM_NAV_PATHS.includes(item.to));
+
+  return (
+    <nav
+      aria-label="Primary"
+      className="fixed bottom-0 left-0 right-0 z-30 flex items-stretch border-t border-border bg-app/95 backdrop-blur pb-[env(safe-area-inset-bottom)]"
+    >
+      {items.map((item) => (
+        <Link
+          key={item.to}
+          to={item.to}
+          activeOptions={item.to === "/" ? { exact: true } : undefined}
+          className={ITEM}
+          activeProps={{ className: ACTIVE }}
+          inactiveProps={{ className: INACTIVE }}
+        >
+          <TabIcon label={item.label}>{item.icon}</TabIcon>
+          <span className="w-full truncate px-0.5 text-center">{item.label}</span>
+        </Link>
+      ))}
+      <button
+        type="button"
+        onClick={openMobileSidebar}
+        aria-label="Open menu"
+        aria-expanded={mobileOpen}
+        className={`${ITEM} ${mobileOpen ? ACTIVE : INACTIVE}`}
+      >
+        <Menu size={22} className="flex-shrink-0" aria-hidden />
+        <span className="w-full truncate px-0.5 text-center">More</span>
+      </button>
+    </nav>
+  );
+}

--- a/apps/web/src/components/public-playlist-card.tsx
+++ b/apps/web/src/components/public-playlist-card.tsx
@@ -1,0 +1,37 @@
+import { Link } from "@tanstack/react-router";
+import { playlistListId } from "../lib/playlist-url";
+import { proxyImage } from "../lib/proxy";
+import type { PublicPlaylistInfo } from "../types/playlist";
+
+type Props = {
+  playlist: PublicPlaylistInfo;
+};
+
+export function PublicPlaylistCard({ playlist }: Props) {
+  const list = playlistListId(playlist.url);
+  if (!list) return null;
+  const count = playlist.streamCount === 1 ? "1 video" : `${playlist.streamCount} videos`;
+
+  return (
+    <Link to="/playlist" search={{ list }} className="group flex flex-col gap-2">
+      <div className="relative aspect-video overflow-hidden rounded-xl bg-surface-strong">
+        <img
+          src={proxyImage(playlist.thumbnailUrl)}
+          alt={playlist.title}
+          className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+          loading="lazy"
+          decoding="async"
+        />
+        <div className="absolute bottom-1.5 right-1.5 rounded-md bg-black/80 px-1.5 py-0.5 text-[11px] font-medium text-white">
+          {count}
+        </div>
+      </div>
+      <div className="min-w-0 px-1">
+        <p className="line-clamp-2 text-sm font-medium leading-snug text-fg group-hover:text-white">
+          {playlist.title}
+        </p>
+        <p className="mt-1 truncate text-xs text-fg-muted">{playlist.uploaderName}</p>
+      </div>
+    </Link>
+  );
+}

--- a/apps/web/src/components/public-playlist-header.tsx
+++ b/apps/web/src/components/public-playlist-header.tsx
@@ -1,0 +1,29 @@
+import { proxyImage } from "../lib/proxy";
+import type { PublicPlaylistInfo } from "../types/playlist";
+
+type Props = {
+  info: PublicPlaylistInfo;
+};
+
+export function PublicPlaylistHeader({ info }: Props) {
+  const count = info.streamCount;
+  return (
+    <div className="flex items-center gap-4 flex-wrap">
+      {info.thumbnailUrl && (
+        <img
+          src={proxyImage(info.thumbnailUrl)}
+          alt=""
+          loading="lazy"
+          className="w-40 aspect-video rounded-xl object-cover bg-surface-strong flex-shrink-0"
+        />
+      )}
+      <div className="flex flex-col gap-1 min-w-0">
+        <h1 className="text-lg font-semibold text-fg truncate">{info.title}</h1>
+        {info.uploaderName && <p className="text-sm text-fg-muted truncate">{info.uploaderName}</p>}
+        <p className="text-xs text-fg-soft">
+          {count} video{count !== 1 ? "s" : ""}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/search-results-grid.tsx
+++ b/apps/web/src/components/search-results-grid.tsx
@@ -1,0 +1,32 @@
+import type { PublicPlaylistInfo } from "../types/playlist";
+import type { VideoStream } from "../types/stream";
+import { PublicPlaylistCard } from "./public-playlist-card";
+import { VideoCard } from "./video-card";
+
+export type SearchResultItem =
+  | { kind: "video"; stream: VideoStream }
+  | { kind: "playlist"; playlist: PublicPlaylistInfo };
+
+type Props = {
+  items: SearchResultItem[];
+};
+
+export function SearchResultsGrid({ items }: Props) {
+  return (
+    <div className="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2 sm:gap-y-8 md:grid-cols-3 lg:grid-cols-4">
+      {items.map((item, index) => (
+        <div
+          key={item.kind === "video" ? item.stream.id : item.playlist.url}
+          className="animate-card-pop-in"
+          style={{ animationDelay: `${Math.min(index * 45, 270)}ms` }}
+        >
+          {item.kind === "video" ? (
+            <VideoCard stream={item.stream} />
+          ) : (
+            <PublicPlaylistCard playlist={item.playlist} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/watch-description.tsx
+++ b/apps/web/src/components/watch-description.tsx
@@ -1,13 +1,18 @@
 import { useState } from "react";
+import { useClientLocale } from "../hooks/use-client-locale";
+import { formatExactDate } from "../lib/format";
 import { RichText } from "./rich-text";
 
 type Props = {
   description: string;
+  uploadedAt?: number;
   onSeekTimestamp?: (seconds: number) => void;
 };
 
-export function WatchDescription({ description, onSeekTimestamp }: Props) {
+export function WatchDescription({ description, uploadedAt, onSeekTimestamp }: Props) {
   const [expanded, setExpanded] = useState(false);
+  const locale = useClientLocale();
+  const exactDate = formatExactDate(uploadedAt, locale);
 
   if (!expanded) {
     return (
@@ -28,6 +33,7 @@ export function WatchDescription({ description, onSeekTimestamp }: Props) {
 
   return (
     <div className="bg-surface rounded-xl px-4 py-3">
+      {exactDate && <p className="mb-2 text-xs font-medium text-fg-muted">{exactDate}</p>}
       <p className="text-sm text-fg leading-relaxed whitespace-pre-wrap">
         <RichText text={description} onSeekTimestamp={onSeekTimestamp} />
       </p>

--- a/apps/web/src/components/watch-icons.tsx
+++ b/apps/web/src/components/watch-icons.tsx
@@ -121,3 +121,21 @@ export function BugIcon() {
     </SvgIcon>
   );
 }
+
+export function ThumbsUpIcon() {
+  return (
+    <SvgIcon label="Likes">
+      <path d="M7 10v12" />
+      <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z" />
+    </SvgIcon>
+  );
+}
+
+export function ThumbsDownIcon() {
+  return (
+    <SvgIcon label="Dislikes">
+      <path d="M17 14V2" />
+      <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z" />
+    </SvgIcon>
+  );
+}

--- a/apps/web/src/components/watch-info.tsx
+++ b/apps/web/src/components/watch-info.tsx
@@ -7,6 +7,7 @@ import { ChannelAvatar } from "./channel-avatar";
 import { ChannelRouteLink } from "./channel-route-link";
 import { Toast } from "./toast";
 import { VerifiedBadgeIcon } from "./watch-icons";
+import { WatchLikeDislike } from "./watch-like-dislike";
 
 type Props = {
   stream: VideoStream;
@@ -99,21 +100,24 @@ export function WatchInfo({ stream }: Props) {
             </div>
           )}
         </div>
-        {stream.channelUrl && (
-          <button
-            type="button"
-            onClick={handleSubscribe}
-            disabled={add.isPending || remove.isPending}
-            aria-pressed={subscribed}
-            className={`flex-shrink-0 px-4 py-1.5 text-sm font-medium rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 focus-visible:ring-border disabled:opacity-50 disabled:cursor-not-allowed ${
-              subscribed
-                ? "ring-1 ring-border-strong bg-surface-strong text-fg hover:bg-surface-soft"
-                : "bg-fg text-app hover:bg-white"
-            }`}
-          >
-            {subscribed ? "Subscribed" : "Subscribe"}
-          </button>
-        )}
+        <div className="flex items-center gap-3 flex-shrink-0">
+          <WatchLikeDislike stream={stream} />
+          {stream.channelUrl && (
+            <button
+              type="button"
+              onClick={handleSubscribe}
+              disabled={add.isPending || remove.isPending}
+              aria-pressed={subscribed}
+              className={`flex-shrink-0 px-4 py-1.5 text-sm font-medium rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 focus-visible:ring-border disabled:opacity-50 disabled:cursor-not-allowed ${
+                subscribed
+                  ? "ring-1 ring-border-strong bg-surface-strong text-fg hover:bg-surface-soft"
+                  : "bg-fg text-app hover:bg-white"
+              }`}
+            >
+              {subscribed ? "Subscribed" : "Subscribe"}
+            </button>
+          )}
+        </div>
       </div>
       <div className="h-px bg-surface-strong" />
       <Toast message={toastMsg} />

--- a/apps/web/src/components/watch-like-dislike.tsx
+++ b/apps/web/src/components/watch-like-dislike.tsx
@@ -1,0 +1,30 @@
+import { formatLikes } from "../lib/format";
+import type { VideoStream } from "../types/stream";
+import { ThumbsDownIcon, ThumbsUpIcon } from "./watch-icons";
+
+type Props = {
+  stream: VideoStream;
+};
+
+export function WatchLikeDislike({ stream }: Props) {
+  const hasLikes = typeof stream.likes === "number" && stream.likes >= 0;
+  const hasDislikes = typeof stream.dislikes === "number" && stream.dislikes >= 0;
+  if (!hasLikes && !hasDislikes) return null;
+
+  return (
+    <div className="flex items-center gap-3 text-sm text-fg-muted">
+      {hasLikes && (
+        <span className="flex items-center gap-1.5">
+          <ThumbsUpIcon />
+          {formatLikes(stream.likes ?? 0)}
+        </span>
+      )}
+      {hasDislikes && (
+        <span className="flex items-center gap-1.5">
+          <ThumbsDownIcon />
+          {formatLikes(stream.dislikes ?? 0)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/watch-meta.tsx
+++ b/apps/web/src/components/watch-meta.tsx
@@ -16,7 +16,11 @@ export function WatchMeta({ stream, showComments = true, onSeekTimestamp }: Prop
       <WatchInfo stream={stream} />
       <WatchActions stream={stream} />
       {stream.description && (
-        <WatchDescription description={stream.description} onSeekTimestamp={onSeekTimestamp} />
+        <WatchDescription
+          description={stream.description}
+          uploadedAt={stream.publishedAt}
+          onSeekTimestamp={onSeekTimestamp}
+        />
       )}
       {showComments && (
         <WatchComments key={stream.id} videoUrl={stream.id} onSeekTimestamp={onSeekTimestamp} />

--- a/apps/web/src/hooks/use-channel-playlists.ts
+++ b/apps/web/src/hooks/use-channel-playlists.ts
@@ -1,0 +1,24 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchChannelPlaylists } from "../lib/api-channel-playlists";
+import type { PublicPlaylistInfo } from "../types/playlist";
+
+type ChannelPlaylistsPage = {
+  playlists: PublicPlaylistInfo[];
+  nextpage: string | null;
+};
+
+export function useChannelPlaylists(channelUrl: string) {
+  return useInfiniteQuery({
+    queryKey: ["channel-playlists", channelUrl],
+    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+      const res = await fetchChannelPlaylists(channelUrl, pageParam);
+      return {
+        playlists: res.playlists ?? [],
+        nextpage: res.nextpage,
+      } satisfies ChannelPlaylistsPage;
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (last: ChannelPlaylistsPage) => last.nextpage ?? undefined,
+    enabled: channelUrl.length > 0,
+  });
+}

--- a/apps/web/src/hooks/use-public-playlist.ts
+++ b/apps/web/src/hooks/use-public-playlist.ts
@@ -1,0 +1,28 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchPublicPlaylist } from "../lib/api";
+import { mapVideoItem } from "../lib/mappers";
+import type { PublicPlaylistInfo } from "../types/playlist";
+import type { VideoStream } from "../types/stream";
+
+type PublicPlaylistPage = {
+  playlist: PublicPlaylistInfo;
+  streams: VideoStream[];
+  nextpage: string | null;
+};
+
+export function usePublicPlaylist(url: string) {
+  return useInfiniteQuery({
+    queryKey: ["public-playlist", url],
+    queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
+      const response = await fetchPublicPlaylist(url, pageParam);
+      return {
+        playlist: response.playlist,
+        streams: response.videos.map(mapVideoItem),
+        nextpage: response.nextpage,
+      } satisfies PublicPlaylistPage;
+    },
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (last: PublicPlaylistPage) => last.nextpage ?? undefined,
+    enabled: url.length > 0,
+  });
+}

--- a/apps/web/src/hooks/use-search.ts
+++ b/apps/web/src/hooks/use-search.ts
@@ -1,10 +1,12 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { fetchSearch } from "../lib/api";
 import { mapVideoItem } from "../lib/mappers";
+import type { PublicPlaylistInfo } from "../types/playlist";
 import type { VideoStream } from "../types/stream";
 
 type SearchPage = {
   streams: VideoStream[];
+  playlists: PublicPlaylistInfo[];
   nextpage: string | null;
   searchSuggestion: string | null;
   isCorrectedSearch: boolean;
@@ -17,6 +19,7 @@ export function useSearch(q: string, service: number) {
       const response = await fetchSearch(q, service, pageParam);
       return {
         streams: response.items.map(mapVideoItem),
+        playlists: response.playlists ?? [],
         nextpage: response.nextpage,
         searchSuggestion: response.searchSuggestion,
         isCorrectedSearch: response.isCorrectedSearch,

--- a/apps/web/src/hooks/use-settings.ts
+++ b/apps/web/src/hooks/use-settings.ts
@@ -8,6 +8,7 @@ const KEY = ["settings"];
 
 const DEFAULTS: SettingsItem = {
   defaultService: 0,
+  defaultLandingPage: "home",
   defaultQuality: "1080p",
   autoplay: true,
   volume: 1,

--- a/apps/web/src/lib/api-channel-playlists.ts
+++ b/apps/web/src/lib/api-channel-playlists.ts
@@ -1,0 +1,12 @@
+import type { ChannelPlaylistsResponse } from "../types/playlist";
+import { request } from "./api";
+import { API_BASE as BASE } from "./env";
+
+export function fetchChannelPlaylists(
+  url: string,
+  nextpage?: string,
+): Promise<ChannelPlaylistsResponse> {
+  const params = new URLSearchParams({ url });
+  if (nextpage) params.set("nextpage", nextpage);
+  return request(`${BASE}/channel/playlists?${params}`);
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   SearchPageResponse,
   StreamResponse,
 } from "../types/api";
+import type { PublicPlaylistResponse } from "../types/playlist";
 import { recordApiError } from "./api-error-log";
 import { extractRequestId, recordClientEvent } from "./client-debug-log";
 import { sanitizeDebugText, sanitizeRequestPath } from "./debug-sanitize";
@@ -164,4 +165,13 @@ export function fetchSuggestions(query: string, service: number): Promise<string
 
 export function fetchBulletComments(url: string): Promise<BulletCommentsPageResponse> {
   return request(`${BASE}/bullet-comments?url=${encodeURIComponent(url)}`);
+}
+
+export function fetchPublicPlaylist(
+  url: string,
+  nextpage?: string,
+): Promise<PublicPlaylistResponse> {
+  const params = new URLSearchParams({ url });
+  if (nextpage) params.set("nextpage", nextpage);
+  return request(`${BASE}/playlist?${params}`);
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -60,7 +60,7 @@ function toErrorMessage(status: number, statusText: string, body: unknown): stri
   return "Request failed";
 }
 
-async function request<T>(url: string, init?: RequestInit): Promise<T> {
+export async function request<T>(url: string, init?: RequestInit): Promise<T> {
   const method = init?.method ?? "GET";
   let res: Response;
   try {

--- a/apps/web/src/lib/channel-route-url.ts
+++ b/apps/web/src/lib/channel-route-url.ts
@@ -3,10 +3,16 @@ import type { ChannelSort } from "./api";
 const YOUTUBE_CHANNEL_ID_PATTERN = /^UC[A-Za-z0-9_-]{22}$/;
 const YOUTUBE_HANDLE_PATTERN = /^@[A-Za-z0-9._-]{2,48}$/;
 
+export type ChannelTab = "videos" | "live" | "playlists";
+
+export function channelTabOrDefault(value: unknown): ChannelTab {
+  return value === "live" || value === "playlists" ? value : "videos";
+}
+
 export type ChannelPathSearch = {
   sort?: ChannelSort;
   q?: string;
-  tab?: "live";
+  tab?: "live" | "playlists";
 };
 
 export type ChannelLegacySearch = ChannelPathSearch & {
@@ -54,13 +60,13 @@ export function toChannelPathParam(sourceUrl: string): string | null {
 export function channelPathSearch(
   sort: ChannelSort,
   query: string,
-  live = false,
+  tab: ChannelTab = "videos",
 ): ChannelPathSearch {
   const trimmedQuery = query.trim();
   const search: ChannelPathSearch = {};
   if (sort !== "latest") search.sort = sort;
   if (trimmedQuery.length > 0) search.q = trimmedQuery;
-  if (live) search.tab = "live";
+  if (tab !== "videos") search.tab = tab;
   return search;
 }
 
@@ -68,7 +74,7 @@ export function channelLegacySearch(
   sourceUrl: string,
   sort: ChannelSort,
   query: string,
-  live = false,
+  tab: ChannelTab = "videos",
 ): ChannelLegacySearch {
-  return { url: toPublicChannelParam(sourceUrl), ...channelPathSearch(sort, query, live) };
+  return { url: toPublicChannelParam(sourceUrl), ...channelPathSearch(sort, query, tab) };
 }

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -63,3 +63,15 @@ export function formatPublishedDate(
 
   return "";
 }
+
+export function formatExactDate(publishedAt: number | undefined, locale?: string): string {
+  if (!publishedAt || publishedAt <= 0) return "";
+  const parsed = new Date(publishedAt);
+  if (Number.isNaN(parsed.getTime())) return "";
+  const effective = locale && locale.trim().length > 0 ? locale : undefined;
+  return parsed.toLocaleDateString(effective, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}

--- a/apps/web/src/lib/playlist-url.ts
+++ b/apps/web/src/lib/playlist-url.ts
@@ -1,0 +1,7 @@
+export function playlistListId(url: string): string | null {
+  try {
+    return new URL(url).searchParams.get("list");
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as ProfileRouteImport } from './routes/profile'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as PodcastsRouteImport } from './routes/podcasts'
 import { Route as PlaylistsRouteImport } from './routes/playlists'
+import { Route as PlaylistRouteImport } from './routes/playlist'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ImportRouteImport } from './routes/import'
 import { Route as HistoryRouteImport } from './routes/history'
@@ -94,6 +95,11 @@ const PlaylistsRoute = PlaylistsRouteImport.update({
   path: '/playlists',
   getParentRoute: () => rootRouteImport,
 } as any)
+const PlaylistRoute = PlaylistRouteImport.update({
+  id: '/playlist',
+  path: '/playlist',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
@@ -163,6 +169,7 @@ export interface FileRoutesByFullPath {
   '/history': typeof HistoryRoute
   '/import': typeof ImportRouteWithChildren
   '/login': typeof LoginRoute
+  '/playlist': typeof PlaylistRoute
   '/playlists': typeof PlaylistsRoute
   '/podcasts': typeof PodcastsRoute
   '/privacy': typeof PrivacyRoute
@@ -188,6 +195,7 @@ export interface FileRoutesByTo {
   '/favorites': typeof FavoritesRoute
   '/history': typeof HistoryRoute
   '/login': typeof LoginRoute
+  '/playlist': typeof PlaylistRoute
   '/playlists': typeof PlaylistsRoute
   '/podcasts': typeof PodcastsRoute
   '/privacy': typeof PrivacyRoute
@@ -215,6 +223,7 @@ export interface FileRoutesById {
   '/history': typeof HistoryRoute
   '/import': typeof ImportRouteWithChildren
   '/login': typeof LoginRoute
+  '/playlist': typeof PlaylistRoute
   '/playlists': typeof PlaylistsRoute
   '/podcasts': typeof PodcastsRoute
   '/privacy': typeof PrivacyRoute
@@ -243,6 +252,7 @@ export interface FileRouteTypes {
     | '/history'
     | '/import'
     | '/login'
+    | '/playlist'
     | '/playlists'
     | '/podcasts'
     | '/privacy'
@@ -268,6 +278,7 @@ export interface FileRouteTypes {
     | '/favorites'
     | '/history'
     | '/login'
+    | '/playlist'
     | '/playlists'
     | '/podcasts'
     | '/privacy'
@@ -294,6 +305,7 @@ export interface FileRouteTypes {
     | '/history'
     | '/import'
     | '/login'
+    | '/playlist'
     | '/playlists'
     | '/podcasts'
     | '/privacy'
@@ -321,6 +333,7 @@ export interface RootRouteChildren {
   HistoryRoute: typeof HistoryRoute
   ImportRoute: typeof ImportRouteWithChildren
   LoginRoute: typeof LoginRoute
+  PlaylistRoute: typeof PlaylistRoute
   PlaylistsRoute: typeof PlaylistsRoute
   PodcastsRoute: typeof PodcastsRoute
   PrivacyRoute: typeof PrivacyRoute
@@ -421,6 +434,13 @@ declare module '@tanstack/react-router' {
       path: '/playlists'
       fullPath: '/playlists'
       preLoaderRoute: typeof PlaylistsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/playlist': {
+      id: '/playlist'
+      path: '/playlist'
+      fullPath: '/playlist'
+      preLoaderRoute: typeof PlaylistRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -533,6 +553,7 @@ const rootRouteChildren: RootRouteChildren = {
   HistoryRoute: HistoryRoute,
   ImportRoute: ImportRouteWithChildren,
   LoginRoute: LoginRoute,
+  PlaylistRoute: PlaylistRoute,
   PlaylistsRoute: PlaylistsRoute,
   PodcastsRoute: PodcastsRoute,
   PrivacyRoute: PrivacyRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, Outlet, useRouterState } from "@tanstack/react-router";
 import { useEffect } from "react";
+import { MobileTabBar } from "../components/mobile-tab-bar";
 import { Navbar } from "../components/navbar";
 import { Sidebar } from "../components/sidebar";
 import { useAuth } from "../hooks/use-auth";
@@ -101,9 +102,13 @@ function RootLayout() {
   }
 
   const topPadding = { paddingTop: "calc(3.5rem + env(safe-area-inset-top, 0px))" };
+  const showTabBar = isMobile && !shortsPage && !watchCinemaPage;
+  const mainBottomPad = showTabBar
+    ? "pb-[calc(env(safe-area-inset-bottom)+4.5rem)]"
+    : "pb-5 sm:pb-6";
   const mainClasses = watchCinemaPage
     ? `transition-all duration-200 ${isMobile ? "ml-0" : collapsed ? "ml-14" : "ml-48"}`
-    : `px-3 sm:px-4 pb-5 sm:pb-6 transition-all duration-200 ${
+    : `px-3 sm:px-4 ${mainBottomPad} transition-all duration-200 ${
         isMobile ? "ml-0" : collapsed ? "ml-14" : "ml-48"
       }`;
 
@@ -114,6 +119,7 @@ function RootLayout() {
       <main className={mainClasses} style={topPadding}>
         <Outlet />
       </main>
+      {showTabBar && <MobileTabBar />}
     </div>
   );
 }

--- a/apps/web/src/routes/channel.tsx
+++ b/apps/web/src/routes/channel.tsx
@@ -6,28 +6,34 @@ import type { ChannelSort } from "../lib/api";
 import {
   channelLegacySearch,
   channelPathSearch,
+  channelTabOrDefault,
   toChannelPathParam,
   toChannelSourceUrl,
 } from "../lib/channel-route-url";
 import { splitChannelSearchUrl } from "../lib/channel-search-url";
 import { channelSortOrDefault } from "../lib/channel-sort";
 
-type ChannelRouteSearch = { url: string; sort?: ChannelSort; q?: string; tab?: "live" };
+type ChannelRouteSearch = {
+  url: string;
+  sort?: ChannelSort;
+  q?: string;
+  tab?: "live" | "playlists";
+};
 
 function validateChannelSearch(search: Record<string, unknown>): ChannelRouteSearch {
   const rawUrl = typeof search.url === "string" ? search.url : "";
   const parsed = splitChannelSearchUrl(toChannelSourceUrl(rawUrl));
   const sort = channelSortOrDefault(search.sort);
   const query = typeof search.q === "string" ? search.q.trim() : parsed.query;
-  const live = search.tab === "live";
-  return channelLegacySearch(parsed.channelUrl, sort, query, live);
+  const tab = channelTabOrDefault(search.tab);
+  return channelLegacySearch(parsed.channelUrl, sort, query, tab);
 }
 
 function LegacyChannelPage() {
   const { url, sort: searchSort, q } = Route.useSearch();
   const sort = searchSort ?? "latest";
   const searchQuery = q ?? "";
-  const live = Route.useSearch().tab === "live";
+  const tab = channelTabOrDefault(Route.useSearch().tab);
   const sourceUrl = toChannelSourceUrl(url);
   const channelId = toChannelPathParam(sourceUrl);
   const navigate = useNavigate({ from: "/channel" });
@@ -37,10 +43,10 @@ function LegacyChannelPage() {
     navigate({
       to: "/channel/$channelId",
       params: { channelId },
-      search: channelPathSearch(sort, searchQuery, live),
+      search: channelPathSearch(sort, searchQuery, tab),
       replace: true,
     });
-  }, [channelId, live, navigate, searchQuery, sort]);
+  }, [channelId, tab, navigate, searchQuery, sort]);
 
   if (channelId) return <PageSpinner />;
 
@@ -49,10 +55,10 @@ function LegacyChannelPage() {
       sourceUrl={sourceUrl}
       sort={sort}
       searchQuery={searchQuery}
-      live={live}
-      onNavigate={(nextSort, nextQuery, nextLive) =>
+      tab={tab}
+      onNavigate={(nextSort, nextQuery, nextTab) =>
         navigate({
-          search: channelLegacySearch(sourceUrl, nextSort, nextQuery, nextLive),
+          search: channelLegacySearch(sourceUrl, nextSort, nextQuery, nextTab),
           replace: true,
         })
       }

--- a/apps/web/src/routes/channel_.$channelId.tsx
+++ b/apps/web/src/routes/channel_.$channelId.tsx
@@ -1,16 +1,20 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { ChannelPageContent } from "../components/channel-page-content";
 import type { ChannelSort } from "../lib/api";
-import { channelPathSearch, toChannelSourceUrl } from "../lib/channel-route-url";
+import {
+  channelPathSearch,
+  channelTabOrDefault,
+  toChannelSourceUrl,
+} from "../lib/channel-route-url";
 import { channelSortOrDefault } from "../lib/channel-sort";
 
-type ChannelPathRouteSearch = { sort?: ChannelSort; q?: string; tab?: "live" };
+type ChannelPathRouteSearch = { sort?: ChannelSort; q?: string; tab?: "live" | "playlists" };
 
 function validateChannelPathSearch(search: Record<string, unknown>): ChannelPathRouteSearch {
   const sort = channelSortOrDefault(search.sort);
   const query = typeof search.q === "string" ? search.q.trim() : "";
-  const live = search.tab === "live";
-  return channelPathSearch(sort, query, live);
+  const tab = channelTabOrDefault(search.tab);
+  return channelPathSearch(sort, query, tab);
 }
 
 function ChannelPathPage() {
@@ -18,7 +22,7 @@ function ChannelPathPage() {
   const { sort: searchSort, q } = Route.useSearch();
   const sort = searchSort ?? "latest";
   const searchQuery = q ?? "";
-  const live = Route.useSearch().tab === "live";
+  const tab = channelTabOrDefault(Route.useSearch().tab);
   const sourceUrl = toChannelSourceUrl(channelId);
   const navigate = useNavigate({ from: "/channel/$channelId" });
 
@@ -27,9 +31,9 @@ function ChannelPathPage() {
       sourceUrl={sourceUrl}
       sort={sort}
       searchQuery={searchQuery}
-      live={live}
-      onNavigate={(nextSort, nextQuery, nextLive) =>
-        navigate({ search: channelPathSearch(nextSort, nextQuery, nextLive), replace: true })
+      tab={tab}
+      onNavigate={(nextSort, nextQuery, nextTab) =>
+        navigate({ search: channelPathSearch(nextSort, nextQuery, nextTab), replace: true })
       }
     />
   );

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,13 +1,42 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
 import { ContinueWatching } from "../components/continue-watching";
 import { HomeFallbackSection } from "../components/home-fallback-section";
 import { HomeRecommendationsSection } from "../components/home-recommendations-section";
 import { useAuth } from "../hooks/use-auth";
 import { useSettings } from "../hooks/use-settings";
 
+let landingApplied = false;
+
+function landingPath(value: string) {
+  switch (value) {
+    case "subscriptions":
+      return "/subscriptions";
+    case "history":
+      return "/history";
+    case "playlists":
+      return "/playlists";
+    case "watch-later":
+      return "/watch-later";
+    case "favorites":
+      return "/favorites";
+    default:
+      return null;
+  }
+}
+
 function HomePage() {
   const { authReady, isAuthed } = useAuth();
-  const { settings } = useSettings();
+  const { settings, settingsReady } = useSettings();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (landingApplied || !settingsReady) return;
+    landingApplied = true;
+    const target = landingPath(settings.defaultLandingPage);
+    if (target) navigate({ to: target, replace: true });
+  }, [settingsReady, settings.defaultLandingPage, navigate]);
+
   if (!authReady) {
     return (
       <div className="min-h-[40vh] flex items-center justify-center">

--- a/apps/web/src/routes/playlist.tsx
+++ b/apps/web/src/routes/playlist.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useCallback } from "react";
+import { PublicPlaylistHeader } from "../components/public-playlist-header";
+import { ScrollSentinel } from "../components/scroll-sentinel";
+import { VideoGrid } from "../components/video-grid";
+import { VideoGridSkeleton } from "../components/video-grid-skeleton";
+import { useBlockedFilter } from "../hooks/use-blocked-filter";
+import { usePublicPlaylist } from "../hooks/use-public-playlist";
+
+function PublicPlaylistPage() {
+  const { list } = Route.useSearch();
+  const playlistUrl = list ? `https://www.youtube.com/playlist?list=${list}` : "";
+  const { data, isLoading, isError, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    usePublicPlaylist(playlistUrl);
+  const { filter } = useBlockedFilter();
+
+  const loadMore = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (!list) return <p className="text-fg-muted text-sm">No playlist selected.</p>;
+  if (isLoading) return <VideoGridSkeleton idPrefix="public-playlist" />;
+  if (isError || !data) {
+    return (
+      <div className="flex flex-col items-center justify-center py-32 gap-2 text-center">
+        <p className="text-fg-muted text-sm">This playlist could not be loaded.</p>
+        <Link to="/" className="text-xs text-fg-soft hover:text-fg-muted transition-colors">
+          Back home
+        </Link>
+      </div>
+    );
+  }
+
+  const info = data.pages[0]?.playlist;
+  const streams = filter(data.pages.flatMap((p) => p.streams));
+
+  return (
+    <div className="flex flex-col gap-6 [animation:page-fade-in_0.2s_ease-out]">
+      {info && <PublicPlaylistHeader info={info} />}
+      {streams.length === 0 ? (
+        <p className="text-fg-muted text-sm">This playlist has no videos.</p>
+      ) : (
+        <VideoGrid streams={streams} />
+      )}
+      {isFetchingNextPage && <VideoGridSkeleton idPrefix="public-playlist-next" />}
+      <ScrollSentinel onIntersect={loadMore} enabled={!!hasNextPage && !isFetchingNextPage} />
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/playlist")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    list: typeof search.list === "string" ? search.list : "",
+  }),
+  component: PublicPlaylistPage,
+});

--- a/apps/web/src/routes/search.tsx
+++ b/apps/web/src/routes/search.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 import { ScrollSentinel } from "../components/scroll-sentinel";
-import { VideoGrid } from "../components/video-grid";
+import { type SearchResultItem, SearchResultsGrid } from "../components/search-results-grid";
 import { VideoGridSkeleton } from "../components/video-grid-skeleton";
 import { useBlockedFilter } from "../hooks/use-blocked-filter";
 import { useSearch } from "../hooks/use-search";
@@ -19,7 +19,21 @@ function SearchPage() {
   const firstPage = data?.pages[0];
   const suggestion = firstPage?.searchSuggestion ?? null;
   const isCorrected = firstPage?.isCorrectedSearch ?? false;
-  const streams = filter(data?.pages.flatMap((p) => p.streams) ?? []);
+
+  const seen = new Set<string>();
+  const items: SearchResultItem[] = [];
+  for (const page of data?.pages ?? []) {
+    for (const playlist of page.playlists) {
+      if (seen.has(playlist.url)) continue;
+      seen.add(playlist.url);
+      items.push({ kind: "playlist", playlist });
+    }
+    for (const stream of filter(page.streams)) {
+      if (seen.has(stream.id)) continue;
+      seen.add(stream.id);
+      items.push({ kind: "video", stream });
+    }
+  }
 
   function handleSuggestion() {
     if (!suggestion) return;
@@ -55,10 +69,10 @@ function SearchPage() {
           ?
         </p>
       )}
-      {streams.length === 0 ? (
+      {items.length === 0 ? (
         <p className="text-fg-muted text-sm">No results for &ldquo;{q}&rdquo;</p>
       ) : (
-        <VideoGrid streams={streams} />
+        <SearchResultsGrid items={items} />
       )}
       {isFetchingNextPage && <VideoGridSkeleton idPrefix="search-next" />}
       <ScrollSentinel onIntersect={loadMore} enabled={!!hasNextPage && !isFetchingNextPage} />

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useSettings } from "../hooks/use-settings";
 import { goto } from "../lib/route-redirect";
 import { SettingsBlocked } from "../settings/settings-blocked";
+import { SettingsLandingPage } from "../settings/settings-landing-page";
 import { SettingsLanguage } from "../settings/settings-language";
 import { SettingsPlayback } from "../settings/settings-playback";
 import { SettingsPrivacy } from "../settings/settings-privacy";
@@ -16,6 +17,7 @@ function SettingsPage() {
       <h1 className="text-lg font-semibold text-fg">Settings</h1>
       <SettingsPlayback />
       <SettingsVideoPreferences />
+      <SettingsLandingPage />
       {settings.defaultService === 0 && <SettingsLanguage />}
       <SettingsService />
       <section className="flex flex-col gap-3">

--- a/apps/web/src/settings/settings-landing-page.tsx
+++ b/apps/web/src/settings/settings-landing-page.tsx
@@ -1,0 +1,40 @@
+import { useSettings } from "../hooks/use-settings";
+
+const LANDING_OPTIONS = [
+  { value: "home", label: "Home" },
+  { value: "subscriptions", label: "Subscriptions" },
+  { value: "history", label: "History" },
+  { value: "playlists", label: "Playlists" },
+  { value: "watch-later", label: "Watch later" },
+  { value: "favorites", label: "Favorites" },
+];
+
+export function SettingsLandingPage() {
+  const { settings, update } = useSettings();
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium text-fg-soft uppercase tracking-wider px-1">Startup</p>
+      <div className="bg-surface rounded-xl border border-border px-4 py-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-fg">Default landing page</span>
+          <span className="text-xs text-fg-soft">
+            The page TypeType opens on when you launch it.
+          </span>
+        </div>
+        <select
+          aria-label="Default landing page"
+          value={settings.defaultLandingPage}
+          onChange={(event) => update.mutate({ defaultLandingPage: event.target.value })}
+          className="h-9 w-full rounded-md border border-border-strong bg-surface px-2.5 text-sm text-fg sm:w-48"
+        >
+          {LANDING_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -1,3 +1,4 @@
+import type { PublicPlaylistInfo } from "./playlist";
 import type {
   AudioStreamItem,
   PreviewFrameItem,
@@ -83,6 +84,7 @@ export type StreamResponse = {
 
 export type SearchPageResponse = {
   items: VideoItem[];
+  playlists: PublicPlaylistInfo[];
   nextpage: string | null;
   searchSuggestion: string | null;
   isCorrectedSearch: boolean;

--- a/apps/web/src/types/playlist.ts
+++ b/apps/web/src/types/playlist.ts
@@ -1,1 +1,19 @@
+import type { VideoItem } from "./api";
+
 export type { PlaylistItem } from "./user";
+
+export type PublicPlaylistInfo = {
+  id: string;
+  title: string;
+  url: string;
+  thumbnailUrl: string;
+  uploaderName: string;
+  streamCount: number;
+  playlistType: string;
+};
+
+export type PublicPlaylistResponse = {
+  playlist: PublicPlaylistInfo;
+  videos: VideoItem[];
+  nextpage: string | null;
+};

--- a/apps/web/src/types/playlist.ts
+++ b/apps/web/src/types/playlist.ts
@@ -17,3 +17,8 @@ export type PublicPlaylistResponse = {
   videos: VideoItem[];
   nextpage: string | null;
 };
+
+export type ChannelPlaylistsResponse = {
+  playlists: PublicPlaylistInfo[];
+  nextpage: string | null;
+};

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -69,6 +69,7 @@ export type ProgressItem = {
 
 export type SettingsItem = {
   defaultService: ServiceId;
+  defaultLandingPage: string;
   defaultQuality: string;
   autoplay: boolean;
   volume: number;


### PR DESCRIPTION
## Summary
- add like and dislike counts on the watch page, shown next to the subscribe button
- show the exact upload date in the expanded video description
- add a persistent mobile bottom tab bar so tab switching works from any page
- add public YouTube playlist support with a dedicated playlist page
- surface playlists inside search results and on a new channel playlists tab
- add a default landing page setting to choose the startup page

Issues: #57, #73, #74, #75, #76, #77

## Verification
- bun run check
- bun run build
- bun run knip
- bun run sherif
- git diff --check
- dev CI passed
- dev Docker build passed
