### PR TITLE
feat: add oidc login support

### DIFF
--- a/apps/web/src/components/admin-settings-panel.tsx
+++ b/apps/web/src/components/admin-settings-panel.tsx
@@ -11,32 +11,56 @@ const ROW =
 
 export function AdminSettingsPanel({ settings, pending, onToggle }: Props) {
   return (
-    <section className="rounded-xl border border-border bg-surface/70 p-4">
-      <div className="mb-3">
-        <h2 className="text-sm font-semibold text-fg">Instance access</h2>
-        <p className="text-xs text-fg-soft">Control who can register or browse as guest.</p>
-      </div>
-      <div className="space-y-2">
-        <SettingToggle
-          label="Allow registrations"
-          value={settings.allowRegistration}
-          pending={pending}
-          onClick={() => onToggle("allowRegistration")}
-        />
-        <SettingToggle
-          label="Allow guest mode"
-          value={settings.allowGuest}
-          pending={pending}
-          onClick={() => onToggle("allowGuest")}
-        />
-        <SettingToggle
-          label="Track active sessions"
-          value={settings.activeSessionsEnabled}
-          pending={pending}
-          onClick={() => onToggle("activeSessionsEnabled")}
-        />
-      </div>
-    </section>
+    <div className="space-y-4">
+      <section className="rounded-xl border border-border bg-surface/70 p-4">
+        <div className="mb-3">
+          <h2 className="text-sm font-semibold text-fg">Instance access</h2>
+          <p className="text-xs text-fg-soft">Control who can register or browse as guest.</p>
+        </div>
+        <div className="space-y-2">
+          <SettingToggle
+            label="Allow registrations"
+            value={settings.allowRegistration}
+            pending={pending}
+            onClick={() => onToggle("allowRegistration")}
+          />
+          <SettingToggle
+            label="Allow guest mode"
+            value={settings.allowGuest}
+            pending={pending}
+            onClick={() => onToggle("allowGuest")}
+          />
+          <SettingToggle
+            label="Track active sessions"
+            value={settings.activeSessionsEnabled}
+            pending={pending}
+            onClick={() => onToggle("activeSessionsEnabled")}
+          />
+        </div>
+      </section>
+      <section className="rounded-xl border border-border bg-surface/70 p-4">
+        <div className="mb-3">
+          <h2 className="text-sm font-semibold text-fg">Authentication</h2>
+          <p className="text-xs text-fg-soft">
+            OIDC behavior. Disable local login only when an OIDC provider is configured.
+          </p>
+        </div>
+        <div className="space-y-2">
+          <SettingToggle
+            label="Allow local login (email and password)"
+            value={settings.localLoginEnabled}
+            pending={pending}
+            onClick={() => onToggle("localLoginEnabled")}
+          />
+          <SettingToggle
+            label="Auto-redirect to OIDC provider"
+            value={settings.oidcAutoRedirect}
+            pending={pending}
+            onClick={() => onToggle("oidcAutoRedirect")}
+          />
+        </div>
+      </section>
+    </div>
   );
 }
 

--- a/apps/web/src/components/oidc-sign-in-button.tsx
+++ b/apps/web/src/components/oidc-sign-in-button.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { startOidc } from "../lib/api-oidc";
+import { oidcCallbackUrl } from "../lib/oidc-redirect";
+import { ProviderBrandIcon } from "./provider-brand-icon";
+
+type Props = {
+  providerName: string | null;
+  returnTo?: string;
+};
+
+export function OidcSignInButton({ providerName, returnTo }: Props) {
+  const [pending, setPending] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  async function start() {
+    setPending(true);
+    setFailed(false);
+    try {
+      const { authorizationUrl } = await startOidc(oidcCallbackUrl(), returnTo);
+      window.location.assign(authorizationUrl);
+    } catch {
+      setFailed(true);
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={start}
+        disabled={pending}
+        className="flex h-10 items-center justify-center gap-2 rounded-lg border border-border-strong bg-surface-strong text-sm font-medium text-fg transition-colors hover:bg-surface-soft disabled:opacity-60"
+      >
+        {pending ? (
+          "Redirecting..."
+        ) : (
+          <>
+            <ProviderBrandIcon providerName={providerName} />
+            <span>Continue with {providerName ?? "SSO"}</span>
+          </>
+        )}
+      </button>
+      {failed && <p className="text-xs text-danger">Could not start sign-in. Try again.</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/provider-brand-icon.tsx
+++ b/apps/web/src/components/provider-brand-icon.tsx
@@ -1,0 +1,38 @@
+import { brandIconColor, oidcProviderIcon } from "../lib/oidc-provider-icon";
+import { ServiceIcon } from "./service-icon";
+
+function GoogleGlyph() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 48 48"
+      role="img"
+      aria-label="Google"
+    >
+      <path
+        fill="#EA4335"
+        d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+      />
+      <path
+        fill="#4285F4"
+        d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+      />
+      <path
+        fill="#34A853"
+        d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+      />
+    </svg>
+  );
+}
+
+export function ProviderBrandIcon({ providerName }: { providerName: string | null }) {
+  if ((providerName ?? "").toLowerCase().includes("google")) return <GoogleGlyph />;
+  const icon = oidcProviderIcon(providerName);
+  return <ServiceIcon path={icon.path} color={brandIconColor(icon.hex)} label={icon.title} />;
+}

--- a/apps/web/src/hooks/use-oidc-status.ts
+++ b/apps/web/src/hooks/use-oidc-status.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchOidcStatus } from "../lib/api-oidc";
+
+export function useOidcStatus() {
+  return useQuery({
+    queryKey: ["oidc-status"],
+    queryFn: fetchOidcStatus,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/web/src/lib/api-admin.ts
+++ b/apps/web/src/lib/api-admin.ts
@@ -18,7 +18,9 @@ function isAdminSettings(value: unknown): value is AdminSettings {
     typeof record.allowRegistration === "boolean" &&
     typeof record.allowGuest === "boolean" &&
     typeof record.forceEmailVerification === "boolean" &&
-    typeof record.activeSessionsEnabled === "boolean"
+    typeof record.activeSessionsEnabled === "boolean" &&
+    typeof record.localLoginEnabled === "boolean" &&
+    typeof record.oidcAutoRedirect === "boolean"
   );
 }
 

--- a/apps/web/src/lib/api-oidc.ts
+++ b/apps/web/src/lib/api-oidc.ts
@@ -1,0 +1,35 @@
+import type { OidcStatus } from "../types/auth";
+import { request } from "./api";
+import { API_BASE as BASE } from "./env";
+
+export type OidcStartResult = {
+  authorizationUrl: string;
+};
+
+export type OidcCallbackResult = {
+  accessToken: string;
+  returnTo: string;
+};
+
+export function fetchOidcStatus(): Promise<OidcStatus> {
+  return request(`${BASE}/auth/oidc/status`);
+}
+
+export function startOidc(redirectUri: string, returnTo?: string): Promise<OidcStartResult> {
+  const params = new URLSearchParams({ redirectUri });
+  if (returnTo) params.set("returnTo", returnTo);
+  return request(`${BASE}/auth/oidc/start?${params}`);
+}
+
+export function completeOidc(payload: {
+  code: string;
+  state: string;
+  redirectUri: string;
+}): Promise<OidcCallbackResult> {
+  return request(`${BASE}/auth/oidc/callback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+}

--- a/apps/web/src/lib/auth-routes.ts
+++ b/apps/web/src/lib/auth-routes.ts
@@ -20,7 +20,7 @@ const PROTECTED_PREFIXES = [
   "/settings",
   "/subscriptions",
 ];
-const AUTH_PAGES = ["/login", "/register", "/reset-password"];
+const AUTH_PAGES = ["/login", "/register", "/reset-password", "/auth/oidc/callback"];
 
 export function requiresAuth(pathname: string): boolean {
   return PROTECTED_PREFIXES.some(

--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -2,6 +2,7 @@ import { useAuthStore } from "../stores/auth-store";
 import type { AuthMe } from "../types/auth";
 import { ApiError } from "./api";
 import { fetchMe, loginAuth, logoutAuth, refreshAuth, registerAuth } from "./api-auth";
+import { completeOidc } from "./api-oidc";
 
 type Credentials = {
   identifier: string;
@@ -68,6 +69,16 @@ export async function loginSession(payload: Credentials): Promise<void> {
 export async function registerSession(payload: RegisterPayload): Promise<void> {
   const response = await registerAuth(payload);
   await hydrateSession(response.accessToken);
+}
+
+export async function oidcCallbackSession(payload: {
+  code: string;
+  state: string;
+  redirectUri: string;
+}): Promise<string> {
+  const result = await completeOidc(payload);
+  await hydrateSession(result.accessToken);
+  return result.returnTo;
 }
 
 export async function logoutSession(): Promise<void> {

--- a/apps/web/src/lib/oidc-provider-icon.ts
+++ b/apps/web/src/lib/oidc-provider-icon.ts
@@ -1,0 +1,41 @@
+import {
+  siApple,
+  siAuth0,
+  siAuthelia,
+  siAuthentik,
+  siGithub,
+  siGitlab,
+  siGoogle,
+  siKeycloak,
+  siOkta,
+  siOpenid,
+} from "simple-icons";
+
+type ProviderIcon = { path: string; title: string; hex: string };
+
+const KNOWN: { match: string; icon: ProviderIcon }[] = [
+  { match: "keycloak", icon: siKeycloak },
+  { match: "authentik", icon: siAuthentik },
+  { match: "authelia", icon: siAuthelia },
+  { match: "auth0", icon: siAuth0 },
+  { match: "okta", icon: siOkta },
+  { match: "google", icon: siGoogle },
+  { match: "github", icon: siGithub },
+  { match: "gitlab", icon: siGitlab },
+  { match: "apple", icon: siApple },
+];
+
+export function oidcProviderIcon(providerName: string | null): ProviderIcon {
+  const name = (providerName ?? "").toLowerCase();
+  const found = KNOWN.find((entry) => name.includes(entry.match));
+  return found ? found.icon : siOpenid;
+}
+
+export function brandIconColor(hex: string): string {
+  if (hex.length !== 6) return "currentColor";
+  const r = Number.parseInt(hex.slice(0, 2), 16);
+  const g = Number.parseInt(hex.slice(2, 4), 16);
+  const b = Number.parseInt(hex.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance < 0.25 ? "currentColor" : `#${hex}`;
+}

--- a/apps/web/src/lib/oidc-redirect.ts
+++ b/apps/web/src/lib/oidc-redirect.ts
@@ -1,0 +1,8 @@
+export function oidcCallbackUrl(): string {
+  return `${window.location.origin}/auth/oidc/callback`;
+}
+
+export function safeReturnTo(value: string | null | undefined): string {
+  if (value?.startsWith("/") && !value.startsWith("//")) return value;
+  return "/";
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as PlaylistsIdRouteImport } from './routes/playlists_.$id'
 import { Route as ImportYoutubeRouteImport } from './routes/import/youtube'
 import { Route as ImportPipepipeRouteImport } from './routes/import/pipepipe'
 import { Route as ChannelChannelIdRouteImport } from './routes/channel_.$channelId'
+import { Route as AuthOidcCallbackRouteImport } from './routes/auth.oidc.callback'
 
 const WatchLaterRoute = WatchLaterRouteImport.update({
   id: '/watch-later',
@@ -160,6 +161,11 @@ const ChannelChannelIdRoute = ChannelChannelIdRouteImport.update({
   path: '/channel/$channelId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthOidcCallbackRoute = AuthOidcCallbackRouteImport.update({
+  id: '/auth/oidc/callback',
+  path: '/auth/oidc/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -187,6 +193,7 @@ export interface FileRoutesByFullPath {
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists/$id': typeof PlaylistsIdRoute
   '/import/': typeof ImportIndexRoute
+  '/auth/oidc/callback': typeof AuthOidcCallbackRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -213,6 +220,7 @@ export interface FileRoutesByTo {
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists/$id': typeof PlaylistsIdRoute
   '/import': typeof ImportIndexRoute
+  '/auth/oidc/callback': typeof AuthOidcCallbackRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -241,6 +249,7 @@ export interface FileRoutesById {
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists_/$id': typeof PlaylistsIdRoute
   '/import/': typeof ImportIndexRoute
+  '/auth/oidc/callback': typeof AuthOidcCallbackRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -270,6 +279,7 @@ export interface FileRouteTypes {
     | '/import/youtube'
     | '/playlists/$id'
     | '/import/'
+    | '/auth/oidc/callback'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -296,6 +306,7 @@ export interface FileRouteTypes {
     | '/import/youtube'
     | '/playlists/$id'
     | '/import'
+    | '/auth/oidc/callback'
   id:
     | '__root__'
     | '/'
@@ -323,6 +334,7 @@ export interface FileRouteTypes {
     | '/import/youtube'
     | '/playlists_/$id'
     | '/import/'
+    | '/auth/oidc/callback'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -348,6 +360,7 @@ export interface RootRouteChildren {
   WatchLaterRoute: typeof WatchLaterRoute
   ChannelChannelIdRoute: typeof ChannelChannelIdRoute
   PlaylistsIdRoute: typeof PlaylistsIdRoute
+  AuthOidcCallbackRoute: typeof AuthOidcCallbackRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -527,6 +540,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChannelChannelIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/auth/oidc/callback': {
+      id: '/auth/oidc/callback'
+      path: '/auth/oidc/callback'
+      fullPath: '/auth/oidc/callback'
+      preLoaderRoute: typeof AuthOidcCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -568,6 +588,7 @@ const rootRouteChildren: RootRouteChildren = {
   WatchLaterRoute: WatchLaterRoute,
   ChannelChannelIdRoute: ChannelChannelIdRoute,
   PlaylistsIdRoute: PlaylistsIdRoute,
+  AuthOidcCallbackRoute: AuthOidcCallbackRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/auth.oidc.callback.tsx
+++ b/apps/web/src/routes/auth.oidc.callback.tsx
@@ -1,0 +1,52 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
+import { AuthCard } from "../components/auth-card";
+import { oidcCallbackSession } from "../lib/auth-session";
+import { oidcCallbackUrl, safeReturnTo } from "../lib/oidc-redirect";
+
+function OidcCallbackPage() {
+  const { code, state, error: providerError } = Route.useSearch();
+  const [failed, setFailed] = useState(false);
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+    if (providerError || !code || !state) {
+      setFailed(true);
+      return;
+    }
+    oidcCallbackSession({ code, state, redirectUri: oidcCallbackUrl() })
+      .then((returnTo) => window.location.assign(safeReturnTo(returnTo)))
+      .catch(() => setFailed(true));
+  }, [code, state, providerError]);
+
+  return (
+    <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-4">
+      <AuthCard title="Signing in" subtitle="Completing sign-in with your provider.">
+        {failed ? (
+          <div className="flex flex-col gap-3">
+            <p className="text-sm text-fg-muted">Sign-in could not be completed.</p>
+            <a
+              href="/login"
+              className="h-10 rounded-lg bg-fg text-app text-sm font-medium flex items-center justify-center"
+            >
+              Back to sign in
+            </a>
+          </div>
+        ) : (
+          <p className="text-sm text-fg-soft">Please wait...</p>
+        )}
+      </AuthCard>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/auth/oidc/callback")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    code: typeof search.code === "string" ? search.code : undefined,
+    state: typeof search.state === "string" ? search.state : undefined,
+    error: typeof search.error === "string" ? search.error : undefined,
+  }),
+  component: OidcCallbackPage,
+});

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,28 +1,46 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AuthCard } from "../components/auth-card";
 import { AuthErrorBanner } from "../components/auth-error-banner";
+import { OidcSignInButton } from "../components/oidc-sign-in-button";
 import { Toast } from "../components/toast";
 import { useAuth } from "../hooks/use-auth";
+import { useOidcStatus } from "../hooks/use-oidc-status";
+import { startOidc } from "../lib/api-oidc";
 import { sanitizeRedirect } from "../lib/auth-routes";
 import { loginSession } from "../lib/auth-session";
+import { oidcCallbackUrl } from "../lib/oidc-redirect";
 import { goto } from "../lib/route-redirect";
 
 function LoginPage() {
   const { isAuthed, isGuest } = useAuth();
   const { redirect } = Route.useSearch();
   const target = sanitizeRedirect(redirect);
+  const { data: oidc } = useOidcStatus();
+  const oidcEnabled = oidc?.enabled ?? false;
+  const localEnabled = oidc?.localLoginEnabled ?? true;
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const autoStarted = useRef(false);
 
   useEffect(() => {
     if (!toast) return;
     const id = window.setTimeout(() => setToast(null), 1800);
     return () => window.clearTimeout(id);
   }, [toast]);
+
+  useEffect(() => {
+    if (autoStarted.current || !oidc?.enabled || !oidc.autoRedirect) return;
+    autoStarted.current = true;
+    startOidc(oidcCallbackUrl(), redirect)
+      .then((result) => window.location.assign(result.authorizationUrl))
+      .catch(() => {
+        autoStarted.current = false;
+      });
+  }, [oidc, redirect]);
 
   if (isAuthed && !isGuest) {
     goto(target);
@@ -48,48 +66,66 @@ function LoginPage() {
       <Toast message={toast} />
       <AuthCard title="Sign in" subtitle="Use your account credentials to continue.">
         <AuthErrorBanner message={error} />
-        <form className="flex flex-col gap-3" onSubmit={submitLogin}>
-          <input
-            type="text"
-            autoComplete="username"
-            value={identifier}
-            onChange={(e) => setIdentifier(e.target.value)}
-            placeholder="Email or username"
-            className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
-            required
-          />
-          <input
-            type="password"
-            autoComplete="current-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Password"
-            className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
-            required
-          />
-          <button
-            type="submit"
-            disabled={pending}
-            className="h-10 rounded-lg bg-fg text-app text-sm font-medium disabled:opacity-60"
-          >
-            {pending ? "Signing in..." : "Sign in"}
-          </button>
-        </form>
-        <div className="mt-4 text-xs text-fg-soft flex items-center justify-between">
-          <Link
-            to="/register"
-            search={{ redirect }}
-            className="text-fg-muted hover:text-fg underline underline-offset-2"
-          >
-            Create account
-          </Link>
-          <Link
-            to="/reset-password"
-            className="text-fg-muted hover:text-fg underline underline-offset-2"
-          >
-            Reset password
-          </Link>
-        </div>
+        {oidcEnabled && (
+          <div className="mb-4">
+            <OidcSignInButton providerName={oidc?.providerName ?? null} returnTo={redirect} />
+          </div>
+        )}
+        {oidcEnabled && localEnabled && (
+          <div className="mb-4 flex items-center gap-3 text-[11px] uppercase tracking-wider text-fg-soft">
+            <span className="h-px flex-1 bg-border" />
+            or
+            <span className="h-px flex-1 bg-border" />
+          </div>
+        )}
+        {localEnabled ? (
+          <form className="flex flex-col gap-3" onSubmit={submitLogin}>
+            <input
+              type="text"
+              autoComplete="username"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+              placeholder="Email or username"
+              className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
+              required
+            />
+            <input
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+              className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
+              required
+            />
+            <button
+              type="submit"
+              disabled={pending}
+              className="h-10 rounded-lg bg-fg text-app text-sm font-medium disabled:opacity-60"
+            >
+              {pending ? "Signing in..." : "Sign in"}
+            </button>
+          </form>
+        ) : (
+          !oidcEnabled && <p className="text-sm text-fg-muted">No sign-in method is available.</p>
+        )}
+        {localEnabled && (
+          <div className="mt-4 text-xs text-fg-soft flex items-center justify-between">
+            <Link
+              to="/register"
+              search={{ redirect }}
+              className="text-fg-muted hover:text-fg underline underline-offset-2"
+            >
+              Create account
+            </Link>
+            <Link
+              to="/reset-password"
+              className="text-fg-muted hover:text-fg underline underline-offset-2"
+            >
+              Reset password
+            </Link>
+          </div>
+        )}
       </AuthCard>
     </div>
   );

--- a/apps/web/src/routes/register.tsx
+++ b/apps/web/src/routes/register.tsx
@@ -2,8 +2,10 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { AuthCard } from "../components/auth-card";
 import { AuthErrorBanner } from "../components/auth-error-banner";
+import { OidcSignInButton } from "../components/oidc-sign-in-button";
 import { Toast } from "../components/toast";
 import { useAuth } from "../hooks/use-auth";
+import { useOidcStatus } from "../hooks/use-oidc-status";
 import { useRegisterStatus } from "../hooks/use-register-status";
 import { ApiError } from "../lib/api";
 import { sanitizeRedirect } from "../lib/auth-routes";
@@ -16,6 +18,9 @@ function RegisterPage() {
   const target = sanitizeRedirect(redirect);
   const registerStatus = useRegisterStatus();
   const status = registerStatus.data;
+  const { data: oidc } = useOidcStatus();
+  const oidcEnabled = oidc?.enabled ?? false;
+  const localEnabled = oidc?.localLoginEnabled ?? true;
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -31,11 +36,13 @@ function RegisterPage() {
   }, [toast]);
 
   const closedByPolicy = status ? !status.allowRegistration && !status.bootstrapAvailable : false;
-  const subtitle = status?.bootstrapAvailable
-    ? "Fresh install detected. The first account will be admin."
-    : closedByPolicy
-      ? "Registrations are currently closed."
-      : "Use your email to create an account. You can sign in with email or username.";
+  const subtitle = !localEnabled
+    ? "Local registration is disabled."
+    : status?.bootstrapAvailable
+      ? "Fresh install detected. The first account will be admin."
+      : closedByPolicy
+        ? "Registrations are currently closed."
+        : "Use your email to create an account. You can sign in with email or username.";
   const bannerMessage = error ?? (closedByPolicy ? "Registrations are currently closed." : null);
 
   if (isAuthed && !isGuest) {
@@ -70,42 +77,63 @@ function RegisterPage() {
       <Toast message={toast} />
       <AuthCard title="Create account" subtitle={subtitle}>
         <AuthErrorBanner message={bannerMessage} />
-        <form className="flex flex-col gap-3" onSubmit={submitRegister}>
-          <input
-            type="text"
-            autoComplete="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Name"
-            className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
-            required
-          />
-          <input
-            type="email"
-            autoComplete="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="Email"
-            className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
-            required
-          />
-          <input
-            type="password"
-            autoComplete="new-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Password"
-            className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
-            required
-          />
-          <button
-            type="submit"
-            disabled={pending || closedByPolicy}
-            className="h-10 rounded-lg bg-fg text-app text-sm font-medium disabled:opacity-60"
-          >
-            {closedByPolicy ? "Registrations closed" : pending ? "Creating account..." : "Register"}
-          </button>
-        </form>
+        {oidcEnabled && (
+          <div className="mb-4">
+            <OidcSignInButton providerName={oidc?.providerName ?? null} returnTo={redirect} />
+          </div>
+        )}
+        {oidcEnabled && localEnabled && (
+          <div className="mb-4 flex items-center gap-3 text-[11px] uppercase tracking-wider text-fg-soft">
+            <span className="h-px flex-1 bg-border" />
+            or
+            <span className="h-px flex-1 bg-border" />
+          </div>
+        )}
+        {!localEnabled && !oidcEnabled && (
+          <p className="text-sm text-fg-muted">Local registration is disabled.</p>
+        )}
+        {localEnabled && (
+          <form className="flex flex-col gap-3" onSubmit={submitRegister}>
+            <input
+              type="text"
+              autoComplete="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Name"
+              className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
+              required
+            />
+            <input
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email"
+              className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
+              required
+            />
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password"
+              className="h-10 rounded-lg border border-border-strong bg-app px-3 text-sm text-fg"
+              required
+            />
+            <button
+              type="submit"
+              disabled={pending || closedByPolicy}
+              className="h-10 rounded-lg bg-fg text-app text-sm font-medium disabled:opacity-60"
+            >
+              {closedByPolicy
+                ? "Registrations closed"
+                : pending
+                  ? "Creating account..."
+                  : "Register"}
+            </button>
+          </form>
+        )}
         <div className="mt-4 text-xs text-fg-soft">
           <Link to="/login" search={{ redirect }} className="hover:text-fg-muted">
             Already have an account? Sign in

--- a/apps/web/src/types/admin.ts
+++ b/apps/web/src/types/admin.ts
@@ -3,6 +3,8 @@ export type AdminSettings = {
   allowGuest: boolean;
   forceEmailVerification: boolean;
   activeSessionsEnabled: boolean;
+  localLoginEnabled: boolean;
+  oidcAutoRedirect: boolean;
 };
 
 type AdminSessionNowPlaying = {

--- a/apps/web/src/types/auth.ts
+++ b/apps/web/src/types/auth.ts
@@ -16,6 +16,13 @@ export type AuthResponse = {
   accessToken: string;
 };
 
+export type OidcStatus = {
+  enabled: boolean;
+  providerName: string | null;
+  localLoginEnabled: boolean;
+  autoRedirect: boolean;
+};
+
 export type AuthUser = {
   id: string;
   email: string;


### PR DESCRIPTION
## Summary
- add OIDC sign-in with a "Continue with <provider>" button on the login and register pages
- add the /auth/oidc/callback route that completes the code exchange and starts the session
- support disabling local login and auto-redirecting to the provider, driven by the backend
- surface the local-login and auto-redirect switches in the admin console settings
- add provider brand icons via simple-icons, with an OpenID fallback and a true-color Google logo

Issues: #60

## Verification
- bun run check
- bun run build
- bun run knip
- bun run sherif
- git diff --check
- dev CI passed
- dev Docker build passed
