### PR TITLE
feat: player ux polish and mobile volume/meta fixes

### DIFF
--- a/apps/web/src/components/player-play-pause-indicator.tsx
+++ b/apps/web/src/components/player-play-pause-indicator.tsx
@@ -1,0 +1,42 @@
+import { Pause, Play } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useMediaState } from "../lib/vidstack";
+
+export function PlayerPlayPauseIndicator() {
+  const paused = useMediaState("paused");
+  const canPlay = useMediaState("canPlay");
+  const [pulse, setPulse] = useState(0);
+  const prevPausedRef = useRef(paused);
+  const readyRef = useRef(false);
+
+  useEffect(() => {
+    if (!canPlay) return;
+    if (!readyRef.current) {
+      readyRef.current = true;
+      prevPausedRef.current = paused;
+      return;
+    }
+    if (paused === prevPausedRef.current) return;
+    prevPausedRef.current = paused;
+    setPulse((n) => n + 1);
+  }, [paused, canPlay]);
+
+  useEffect(() => {
+    if (pulse === 0) return;
+    const timer = window.setTimeout(() => setPulse(0), 500);
+    return () => window.clearTimeout(timer);
+  }, [pulse]);
+
+  if (pulse === 0) return null;
+  const Icon = paused ? Pause : Play;
+  return (
+    <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center">
+      <div
+        key={pulse}
+        className="player-pp-pop flex h-16 w-16 items-center justify-center rounded-full bg-black/60 text-white ring-1 ring-white/20 backdrop-blur-sm"
+      >
+        <Icon className="h-7 w-7" aria-hidden="true" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/video-player.tsx
+++ b/apps/web/src/components/video-player.tsx
@@ -13,6 +13,7 @@ import { FormatSelector } from "./format-selector";
 import { MediaSessionSync } from "./media-session-sync";
 import { PlayerHotkeys } from "./player-hotkeys";
 import { PlayerSeeker, SeekBridge, SponsorBlockSkipper } from "./player-internals";
+import { PlayerPlayPauseIndicator } from "./player-play-pause-indicator";
 import { QualitySelector } from "./quality-selector";
 import { SponsorBlockBar } from "./sponsorblock-bar";
 import { SponsorBlockCurrentSegment } from "./sponsorblock-current-segment";
@@ -75,6 +76,7 @@ export function VideoPlayer({
       logLevel="warn"
       crossOrigin
       playsInline
+      hideControlsOnMouseLeave
       {...(ios ? { "webkit-playsinline": "true" } : {})}
       autoPlay={autoplay}
       storage={null}
@@ -143,6 +145,7 @@ export function VideoPlayer({
         isLive={streamType === "live"}
       />
       <PlayerHotkeys canSeek={streamType !== "live"} />
+      <PlayerPlayPauseIndicator />
       {autoSkipSponsorBlock && autoSkipSponsorBlockSegments && (
         <SponsorBlockSkipper
           segments={autoSkipSponsorBlockSegments}

--- a/apps/web/src/components/watch-info.tsx
+++ b/apps/web/src/components/watch-info.tsx
@@ -66,7 +66,7 @@ export function WatchInfo({ stream }: Props) {
           {formatViews(stream.views)}
         </span>
       </div>
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
         <div className="flex items-center gap-3 min-w-0">
           {stream.channelUrl ? (
             <ChannelRouteLink
@@ -100,7 +100,7 @@ export function WatchInfo({ stream }: Props) {
             </div>
           )}
         </div>
-        <div className="flex items-center gap-3 flex-shrink-0">
+        <div className="flex items-center justify-between gap-3 flex-shrink-0 sm:justify-start">
           <WatchLikeDislike stream={stream} />
           {stream.channelUrl && (
             <button

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -107,7 +107,7 @@ function RootLayout() {
     ? "pb-[calc(env(safe-area-inset-bottom)+4.5rem)]"
     : "pb-5 sm:pb-6";
   const mainClasses = watchCinemaPage
-    ? `transition-all duration-200 ${isMobile ? "ml-0" : collapsed ? "ml-14" : "ml-48"}`
+    ? "transition-all duration-200 ml-0"
     : `px-3 sm:px-4 ${mainBottomPad} transition-all duration-200 ${
         isMobile ? "ml-0" : collapsed ? "ml-14" : "ml-48"
       }`;
@@ -115,7 +115,7 @@ function RootLayout() {
   return (
     <div className="min-h-screen bg-app text-fg">
       <Navbar />
-      <Sidebar />
+      {!watchCinemaPage && <Sidebar />}
       <main className={mainClasses} style={topPadding}>
         <Outlet />
       </main>

--- a/apps/web/src/styles/player-hotkeys.css
+++ b/apps/web/src/styles/player-hotkeys.css
@@ -14,3 +14,18 @@
 .player-rabbit-hop {
   animation: player-rabbit-hop 0.52s cubic-bezier(0.34, 1.56, 0.64, 1) infinite;
 }
+
+@keyframes player-pp-pop {
+  from {
+    opacity: 0.9;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 0;
+    transform: scale(1.3);
+  }
+}
+
+.player-pp-pop {
+  animation: player-pp-pop 0.5s ease-out forwards;
+}

--- a/apps/web/src/styles/player-menu-overrides.css
+++ b/apps/web/src/styles/player-menu-overrides.css
@@ -17,3 +17,17 @@
 .vds-captions {
   --media-cue-backdrop: none;
 }
+
+@media (pointer: coarse) {
+  .vds-video-layout[data-lg] .vds-volume-slider {
+    margin-left: var(--gap, 10px);
+    opacity: 1;
+    visibility: visible;
+    max-width: var(--video-volume-slider-max-width, 72px);
+  }
+}
+
+:where(div):has(> [data-media-player][data-fullscreen]) {
+  border-radius: 0;
+  overflow: visible;
+}


### PR DESCRIPTION
## Summary
- show a play/pause popup on every toggle (keyboard, click, gesture)
- make cinema mode edge to edge by hiding the sidebar and removing the content margin
- hide the player controls immediately on mouse leave
- remove the player rounding in fullscreen so the overlay corners are square
- show the volume slider on touch so volume is adjustable on mobile
- stack the watch metadata actions on their own row on mobile

Issues: #86

## Verification
- bun run check
- bun run build
- bun run knip
- bun run sherif
- git diff --check
- dev CI passed
- dev Docker build passed
