### PR TITLE
fix: route youtube session websocket through api

### DIFF
--- a/apps/web/src/components/youtube-session-browser-panel.tsx
+++ b/apps/web/src/components/youtube-session-browser-panel.tsx
@@ -7,6 +7,7 @@ type Props = {
   authReady: boolean;
   isAuthed: boolean;
   enabled: boolean;
+  loaded: boolean;
   pending: boolean;
   connected: boolean;
   returnTo?: string;
@@ -23,6 +24,7 @@ export function YoutubeSessionBrowserPanel({
   authReady,
   isAuthed,
   enabled,
+  loaded,
   pending,
   connected,
   returnTo,
@@ -66,9 +68,11 @@ export function YoutubeSessionBrowserPanel({
         className="mt-5 inline-flex h-11 w-full items-center justify-center gap-2 border border-white bg-white px-5 font-medium text-black text-sm transition-colors hover:bg-fg disabled:opacity-50 sm:w-auto"
       >
         <YoutubeIcon className="h-4 w-4 text-[#ff0000]" />
-        <span>{pending ? "Opening..." : "Connect with YouTube"}</span>
+        <span>
+          {!loaded ? "Checking availability..." : pending ? "Opening..." : "Connect with YouTube"}
+        </span>
       </button>
-      {!enabled && (
+      {loaded && !enabled && (
         <p className="mt-3 text-danger-strong text-xs">
           Remote YouTube login is disabled on this instance.
         </p>

--- a/apps/web/src/lib/youtube-session-route.ts
+++ b/apps/web/src/lib/youtube-session-route.ts
@@ -36,7 +36,7 @@ export function toYoutubeSessionWebSocketUrl(wsUrl: string): string {
   const url =
     wsUrl.startsWith("http://") || wsUrl.startsWith("https://")
       ? new URL(wsUrl)
-      : new URL(wsUrl, apiUrl.origin);
+      : new URL(`${apiUrl.pathname.replace(/\/$/, "")}/${wsUrl.replace(/^\//, "")}`, apiUrl.origin);
   url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
   return url.toString();
 }

--- a/apps/web/src/routes/youtube-session.tsx
+++ b/apps/web/src/routes/youtube-session.tsx
@@ -100,6 +100,7 @@ function YoutubeSessionPage() {
             authReady={authReady}
             isAuthed={isAuthed}
             enabled={remoteLoginEnabled}
+            loaded={instance.isSuccess}
             pending={session.startBrowser.isPending}
             connected={connected}
             returnTo={returnTo}


### PR DESCRIPTION
## Summary
- route YouTube Session WebSocket URLs through the configured API base path
- avoid showing the disabled-state message before instance capabilities finish loading

## Verification
- bun run check
- bun run build
- bun run sherif
- bun run knip
- git diff --check
- verified `/api` maps `/youtube-session/browser/...` to `wss://watch.eltux.fr/api/youtube-session/browser/...`

## Rollback
- roll back the frontend image if YouTube Session WebSocket startup regresses
