### PR TITLE
fix: generate remote login secrets in compose

### DIFF
--- a/apps/web/src/components/playlists-empty-state.tsx
+++ b/apps/web/src/components/playlists-empty-state.tsx
@@ -1,0 +1,8 @@
+export function PlaylistsEmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 py-32 text-center">
+      <p className="text-fg-muted text-sm">No playlists yet.</p>
+      <p className="text-fg-soft text-xs">Use the New playlist button to get started.</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/playlists-page-header.tsx
+++ b/apps/web/src/components/playlists-page-header.tsx
@@ -1,0 +1,60 @@
+type Props = {
+  selectionMode: boolean;
+  selectedCount: number;
+  canSelect: boolean;
+  onSelect: () => void;
+  onCancel: () => void;
+  onDelete: () => void;
+  onCreate: () => void;
+};
+
+export function PlaylistsPageHeader({
+  selectionMode,
+  selectedCount,
+  canSelect,
+  onSelect,
+  onCancel,
+  onDelete,
+  onCreate,
+}: Props) {
+  const base =
+    "rounded-lg bg-surface-strong px-3 py-2 text-sm transition-colors hover:bg-surface-soft";
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <h1 className="font-semibold text-fg text-lg">Playlists</h1>
+      <div className="flex items-center gap-2">
+        {selectionMode ? (
+          <>
+            <span className="text-fg-soft text-xs">{selectedCount} selected</span>
+            <button type="button" onClick={onCancel} className={`${base} text-fg-muted`}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={selectedCount === 0}
+              onClick={onDelete}
+              className="rounded-lg bg-danger px-3 py-2 text-sm text-white transition-colors hover:bg-danger disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Delete ({selectedCount})
+            </button>
+          </>
+        ) : (
+          <>
+            {canSelect && (
+              <button
+                type="button"
+                onClick={onSelect}
+                className={`${base} text-fg-muted hover:text-fg`}
+              >
+                Select
+              </button>
+            )}
+            <button type="button" onClick={onCreate} className={`${base} text-fg`}>
+              New playlist
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/public-playlist-card.tsx
+++ b/apps/web/src/components/public-playlist-card.tsx
@@ -1,5 +1,4 @@
 import { Link } from "@tanstack/react-router";
-import { playlistListId } from "../lib/playlist-url";
 import { proxyImage } from "../lib/proxy";
 import type { PublicPlaylistInfo } from "../types/playlist";
 
@@ -8,12 +7,10 @@ type Props = {
 };
 
 export function PublicPlaylistCard({ playlist }: Props) {
-  const list = playlistListId(playlist.url);
-  if (!list) return null;
   const count = playlist.streamCount === 1 ? "1 video" : `${playlist.streamCount} videos`;
 
   return (
-    <Link to="/playlist" search={{ list }} className="group flex flex-col gap-2">
+    <Link to="/playlist" search={{ url: playlist.url }} className="group flex flex-col gap-2">
       <div className="relative aspect-video overflow-hidden rounded-xl bg-surface-strong">
         <img
           src={proxyImage(playlist.thumbnailUrl)}

--- a/apps/web/src/components/public-playlist-card.tsx
+++ b/apps/web/src/components/public-playlist-card.tsx
@@ -10,7 +10,11 @@ export function PublicPlaylistCard({ playlist }: Props) {
   const count = playlist.streamCount === 1 ? "1 video" : `${playlist.streamCount} videos`;
 
   return (
-    <Link to="/playlist" search={{ url: playlist.url }} className="group flex flex-col gap-2">
+    <Link
+      to="/playlist"
+      search={{ list: undefined, url: playlist.url }}
+      className="group flex flex-col gap-2"
+    >
       <div className="relative aspect-video overflow-hidden rounded-xl bg-surface-strong">
         <img
           src={proxyImage(playlist.thumbnailUrl)}

--- a/apps/web/src/components/saved-playlist-card.tsx
+++ b/apps/web/src/components/saved-playlist-card.tsx
@@ -13,7 +13,7 @@ export function SavedPlaylistCard({ playlist, onDelete }: Props) {
 
   return (
     <div className="group flex flex-col gap-2">
-      <Link to="/playlist" search={{ url: playlist.url }} className="block">
+      <Link to="/playlist" search={{ list: undefined, url: playlist.url }} className="block">
         <div className="relative aspect-video overflow-hidden rounded-xl bg-surface-strong">
           {playlist.thumbnailUrl && (
             <img
@@ -30,7 +30,7 @@ export function SavedPlaylistCard({ playlist, onDelete }: Props) {
         </div>
       </Link>
       <div className="flex items-start justify-between gap-2 px-1">
-        <Link to="/playlist" search={{ url: playlist.url }} className="min-w-0">
+        <Link to="/playlist" search={{ list: undefined, url: playlist.url }} className="min-w-0">
           <p className="line-clamp-2 text-sm font-medium leading-snug text-fg group-hover:text-fg-strong">
             {playlist.title}
           </p>

--- a/apps/web/src/components/saved-playlist-card.tsx
+++ b/apps/web/src/components/saved-playlist-card.tsx
@@ -1,0 +1,50 @@
+import { Link } from "@tanstack/react-router";
+import { Trash2 } from "lucide-react";
+import { proxyImage } from "../lib/proxy";
+import type { SavedPlaylistItem } from "../types/playlist";
+
+type Props = {
+  playlist: SavedPlaylistItem;
+  onDelete: () => void;
+};
+
+export function SavedPlaylistCard({ playlist, onDelete }: Props) {
+  const count = playlist.streamCount === 1 ? "1 video" : `${playlist.streamCount} videos`;
+
+  return (
+    <div className="group flex flex-col gap-2">
+      <Link to="/playlist" search={{ url: playlist.url }} className="block">
+        <div className="relative aspect-video overflow-hidden rounded-xl bg-surface-strong">
+          {playlist.thumbnailUrl && (
+            <img
+              src={proxyImage(playlist.thumbnailUrl)}
+              alt={playlist.title}
+              className="h-full w-full object-cover transition-transform duration-200 group-hover:scale-105"
+              loading="lazy"
+              decoding="async"
+            />
+          )}
+          <div className="absolute bottom-1.5 right-1.5 rounded-md bg-black/80 px-1.5 py-0.5 text-[11px] font-medium text-white">
+            {count}
+          </div>
+        </div>
+      </Link>
+      <div className="flex items-start justify-between gap-2 px-1">
+        <Link to="/playlist" search={{ url: playlist.url }} className="min-w-0">
+          <p className="line-clamp-2 text-sm font-medium leading-snug text-fg group-hover:text-fg-strong">
+            {playlist.title}
+          </p>
+          <p className="mt-1 truncate text-xs text-fg-muted">{playlist.uploaderName}</p>
+        </Link>
+        <button
+          type="button"
+          onClick={onDelete}
+          aria-label="Remove saved playlist"
+          className="mt-0.5 shrink-0 text-fg-soft transition-colors hover:text-danger"
+        >
+          <Trash2 className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/saved-playlists-section.tsx
+++ b/apps/web/src/components/saved-playlists-section.tsx
@@ -1,0 +1,31 @@
+import type { SavedPlaylistItem } from "../types/playlist";
+import { SavedPlaylistCard } from "./saved-playlist-card";
+
+type Props = {
+  playlists: SavedPlaylistItem[];
+  onDelete: (playlist: SavedPlaylistItem) => void;
+};
+
+export function SavedPlaylistsSection({ playlists, onDelete }: Props) {
+  if (playlists.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div>
+        <h2 className="text-sm font-semibold text-fg">Saved public playlists</h2>
+        <p className="text-xs text-fg-soft">Live public playlists saved to your library.</p>
+      </div>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        {playlists.map((playlist, index) => (
+          <div
+            key={playlist.id}
+            className="animate-card-pop-in"
+            style={{ animationDelay: `${Math.min(index * 45, 270)}ms` }}
+          >
+            <SavedPlaylistCard playlist={playlist} onDelete={() => onDelete(playlist)} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -26,6 +26,10 @@ const BTN_BASE = "flex items-center h-10 rounded-lg transition-colors w-full";
 const BTN_ACTIVE = "text-fg bg-surface-strong";
 const BTN_INACTIVE = "text-fg-muted hover:text-fg hover:bg-surface-strong";
 
+type Props = {
+  overlay?: boolean;
+};
+
 function NavIcon({ children, label }: { children: React.ReactNode; label: string }) {
   return (
     <svg
@@ -47,11 +51,12 @@ function NavIcon({ children, label }: { children: React.ReactNode; label: string
   );
 }
 
-export function Sidebar() {
+export function Sidebar({ overlay = false }: Props) {
   const isMobile = useMobile();
   const collapsed = useUiStore((s) => s.sidebarCollapsed);
   const mobileOpen = useUiStore((s) => s.mobileSidebarOpen);
   const closeMobileSidebar = useUiStore((s) => s.closeMobileSidebar);
+  const visualCollapsed = overlay ? false : collapsed;
   const { isAdmin, isAuthed, signOut } = useAuth();
   const { settings, update } = useSettings();
   const service = settings.defaultService;
@@ -73,17 +78,25 @@ export function Sidebar() {
     return true;
   });
 
+  const desktopShell = overlay
+    ? "z-50 border-border border-r bg-app/95 shadow-2xl backdrop-blur"
+    : "z-40 bg-app";
+  const desktopMotion = overlay
+    ? collapsed
+      ? "pointer-events-none -translate-x-full"
+      : "translate-x-0"
+    : "";
   const baseClasses = isMobile
     ? `fixed top-14 left-0 bottom-0 z-50 w-72 max-w-[85vw] bg-app flex flex-col py-4 pb-[calc(env(safe-area-inset-bottom)+1rem)] transition-transform duration-200 ${
         mobileOpen ? "translate-x-0" : "-translate-x-full"
       }`
-    : `fixed top-14 left-0 bottom-0 z-40 bg-app flex flex-col py-4 transition-all duration-200 ${
-        collapsed ? "w-14" : "w-48"
+    : `fixed top-14 left-0 bottom-0 ${desktopShell} ${desktopMotion} flex flex-col py-4 transition-all duration-200 ${
+        visualCollapsed ? "w-14" : "w-48"
       }`;
   const sectionPadding = isMobile ? "px-3" : "px-2";
   const itemLayout = isMobile
     ? "justify-start gap-3 px-2"
-    : collapsed
+    : visualCollapsed
       ? "justify-center px-0"
       : "gap-3 px-2";
 
@@ -113,7 +126,7 @@ export function Sidebar() {
               inactiveProps={{ className: BTN_INACTIVE }}
             >
               <NavIcon label={item.label}>{item.icon}</NavIcon>
-              {(!collapsed || isMobile) && (
+              {(!visualCollapsed || isMobile) && (
                 <span className="text-sm font-medium">{item.label}</span>
               )}
             </Link>
@@ -121,7 +134,7 @@ export function Sidebar() {
         </div>
 
         <div className={`mt-4 ${sectionPadding} border-t border-border pt-4 flex flex-col gap-1`}>
-          {(!collapsed || isMobile) && (
+          {(!visualCollapsed || isMobile) && (
             <p className="text-xs text-fg-soft px-2 mb-1 uppercase tracking-wider">Services</p>
           )}
           {SERVICES.map((svc) => (
@@ -132,13 +145,13 @@ export function Sidebar() {
               className={`${BTN_BASE} ${
                 isMobile
                   ? "justify-start gap-3 px-2 text-left"
-                  : collapsed
+                  : visualCollapsed
                     ? "justify-center px-0"
                     : "gap-3 px-2 text-left"
               } ${service === svc.id ? BTN_ACTIVE : BTN_INACTIVE}`}
             >
               <ServiceIcon path={svc.path} color={svc.color} label={svc.label} />
-              {(!collapsed || isMobile) && <span className="text-sm">{svc.label}</span>}
+              {(!visualCollapsed || isMobile) && <span className="text-sm">{svc.label}</span>}
             </button>
           ))}
         </div>

--- a/apps/web/src/components/watch-layout-classes.ts
+++ b/apps/web/src/components/watch-layout-classes.ts
@@ -1,12 +1,17 @@
 export type WatchLayoutClasses = ReturnType<typeof getWatchLayoutClasses>;
 
-export function getWatchLayoutClasses(cinemaMode: boolean) {
+export function getWatchLayoutClasses(cinemaMode: boolean, hasSecondaryContent: boolean) {
   const anim = "[animation:page-fade-in_0.2s_ease-out]";
+  const standardLayout = hasSecondaryContent
+    ? "pt-2 sm:pt-3 lg:flex-row lg:items-start"
+    : "pt-2 sm:pt-3 lg:items-center";
   return {
-    containerClass: `flex flex-col gap-6 ${cinemaMode ? "" : "pt-2 sm:pt-3 lg:flex-row lg:items-start"} ${anim}`,
+    containerClass: `flex flex-col gap-6 ${cinemaMode ? "" : standardLayout} ${anim}`,
     playerWrapClass: cinemaMode
       ? "overflow-hidden bg-black"
-      : "min-w-0 flex-[2] max-w-[133.333vh] flex flex-col gap-4",
+      : `min-w-0 flex flex-col gap-4 ${
+          hasSecondaryContent ? "flex-[2] max-w-[133.333vh]" : "mx-auto w-full max-w-[1600px]"
+        }`,
     playerBoxClass: cinemaMode
       ? "mx-auto aspect-video w-[min(100%,calc((100svh-4.5rem)*16/9))]"
       : "overflow-hidden rounded-lg",

--- a/apps/web/src/components/watch-layout.tsx
+++ b/apps/web/src/components/watch-layout.tsx
@@ -1,5 +1,4 @@
-import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useBulletComments } from "../hooks/use-bullet-comments";
 import { useMobile } from "../hooks/use-mobile";
 import { usePlayerError } from "../hooks/use-player-error";
@@ -7,6 +6,7 @@ import { usePlayerErrorResume } from "../hooks/use-player-error-resume";
 import { useSaveProgress } from "../hooks/use-progress";
 import { useSettings } from "../hooks/use-settings";
 import { useVolumeSync } from "../hooks/use-volume-sync";
+import { useWatchEndedNavigation } from "../hooks/use-watch-ended-navigation";
 import { useWatchVttAssets } from "../hooks/use-watch-layout-assets";
 import { useWatchPlayerEvents } from "../hooks/use-watch-player-events";
 import { useWatchPlaylist } from "../hooks/use-watch-playlist";
@@ -36,7 +36,6 @@ type Props = {
 };
 
 export function WatchLayout({ stream, startTime, currentParam, navigating, list, shuffle }: Props) {
-  const navigate = useNavigate();
   const isMobile = useMobile();
   const save = useSaveProgress(stream.id);
   const { settings, update, settingsReady } = useSettings();
@@ -77,26 +76,15 @@ export function WatchLayout({ stream, startTime, currentParam, navigating, list,
     return () => clearTimeout(timer);
   }, [toast]);
 
-  const handleEnded = useCallback(() => {
-    if (!settingsReady || !settings.autoplay) return;
-    if (playlist.nextParam) {
-      navigate({
-        to: "/watch",
-        search: { v: playlist.nextParam, list, ...(shuffle ? { shuffle } : {}) },
-      });
-      return;
-    }
-    const next = stream.related?.[0];
-    if (next) navigate({ to: "/watch", search: { v: next.id } });
-  }, [
+  const handleEnded = useWatchEndedNavigation({
     settingsReady,
-    settings.autoplay,
-    playlist.nextParam,
+    autoplay: settings.autoplay,
+    hideRelatedVideos: settings.hideRelatedVideos,
+    nextParam: playlist.nextParam,
     list,
     shuffle,
-    stream.related,
-    navigate,
-  ]);
+    related: stream.related,
+  });
 
   const playerEvents = useWatchPlayerEvents({
     stream,
@@ -127,7 +115,8 @@ export function WatchLayout({ stream, startTime, currentParam, navigating, list,
     />
   );
 
-  const classes = getWatchLayoutClasses(cinemaMode);
+  const hasSecondaryContent = Boolean(!isMobile && (playlist.panel || relatedStreams.length > 0));
+  const classes = getWatchLayoutClasses(cinemaMode, hasSecondaryContent);
 
   return (
     <div className={classes.containerClass}>

--- a/apps/web/src/components/watch-playlist-panel.tsx
+++ b/apps/web/src/components/watch-playlist-panel.tsx
@@ -1,8 +1,7 @@
-import { ChevronDown, Play, Shuffle } from "lucide-react";
-import { type DragEvent, useState } from "react";
+import { ChevronDown, Shuffle } from "lucide-react";
+import { type DragEvent, useEffect, useRef, useState } from "react";
 import { useFlipList } from "../hooks/use-flip-list";
 import { useMobile } from "../hooks/use-mobile";
-import { proxyImage } from "../lib/proxy";
 import { toPublicWatchParam } from "../lib/watch-url";
 import type { WatchPlaylistItem } from "../types/playlist";
 import { WatchPlaylistRow } from "./watch-playlist-row";
@@ -30,15 +29,19 @@ export function WatchPlaylistPanel({
   const [collapsed, setCollapsed] = useState(isMobile);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [overIndex, setOverIndex] = useState<number | null>(null);
+  const currentElement = useRef<HTMLLIElement | null>(null);
   const currentIndex = videos.findIndex((video) => toPublicWatchParam(video.url) === currentParam);
-  const currentVideo = currentIndex >= 0 ? videos[currentIndex] : undefined;
-  const prefix = currentIndex >= 0 ? videos.slice(0, currentIndex + 1) : [];
-  const upNext = currentIndex >= 0 ? videos.slice(currentIndex + 1) : videos;
   const reorderable = Boolean(onReorder);
-  const register = useFlipList(upNext.map((video) => video.key).join("|"));
+  const register = useFlipList(videos.map((video) => video.key).join("|"));
+
+  useEffect(() => {
+    if (!collapsed && currentIndex >= 0) {
+      currentElement.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [collapsed, currentIndex]);
 
   function commit(next: WatchPlaylistItem[]) {
-    onReorder?.([...prefix, ...next]);
+    onReorder?.(next);
   }
   function handleDragStart(event: DragEvent, index: number) {
     setDragIndex(index);
@@ -48,7 +51,7 @@ export function WatchPlaylistPanel({
   }
   function handleDrop(targetIndex: number) {
     if (onReorder && dragIndex !== null && dragIndex !== targetIndex) {
-      const next = [...upNext];
+      const next = [...videos];
       const [moved] = next.splice(dragIndex, 1);
       next.splice(targetIndex, 0, moved);
       commit(next);
@@ -58,8 +61,8 @@ export function WatchPlaylistPanel({
   }
   function moveItem(index: number, direction: number) {
     const target = index + direction;
-    if (!onReorder || target < 0 || target >= upNext.length) return;
-    const next = [...upNext];
+    if (!onReorder || target < 0 || target >= videos.length) return;
+    const next = [...videos];
     const [moved] = next.splice(index, 1);
     next.splice(target, 0, moved);
     commit(next);
@@ -101,66 +104,49 @@ export function WatchPlaylistPanel({
           />
         </button>
       </div>
-      {!collapsed && currentVideo && (
-        <div className="flex items-center gap-2 border-border border-b bg-surface-strong px-3 py-2">
-          <div className="relative aspect-video w-20 shrink-0 overflow-hidden rounded bg-surface">
-            {currentVideo.thumbnail && (
-              <img
-                src={proxyImage(currentVideo.thumbnail)}
-                alt=""
-                className="h-full w-full object-cover"
-                loading="lazy"
-                decoding="async"
-              />
-            )}
-            <div className="absolute inset-0 flex items-center justify-center bg-black/50">
-              <Play className="h-4 w-4 fill-white text-white" aria-hidden="true" />
-            </div>
-          </div>
-          <div className="min-w-0 flex-1">
-            <p className="font-medium text-[11px] text-accent">Now playing</p>
-            <p className="line-clamp-2 font-medium text-fg text-xs leading-snug">
-              {currentVideo.title}
-            </p>
-          </div>
-        </div>
-      )}
       {!collapsed && (
         <ul className="max-h-[24rem] list-none overflow-y-auto py-1">
-          {upNext.map((video, index) => (
-            <li
-              key={video.key}
-              ref={(element) => register(video.key, element)}
-              data-pl-row="true"
-              className={`group flex items-center gap-1 px-1 transition-colors hover:bg-surface-strong/60 ${
-                overIndex === index && dragIndex !== null ? "ring-1 ring-accent ring-inset" : ""
-              } ${dragIndex === index ? "opacity-40" : ""}`}
-              onDragOver={reorderable ? (event) => event.preventDefault() : undefined}
-              onDragEnter={reorderable ? () => setOverIndex(index) : undefined}
-              onDrop={reorderable ? () => handleDrop(index) : undefined}
-              onDragEnd={
-                reorderable
-                  ? () => {
-                      setDragIndex(null);
-                      setOverIndex(null);
-                    }
-                  : undefined
-              }
-            >
-              <WatchPlaylistRow
-                video={video}
-                index={index}
-                total={upNext.length}
-                isCurrent={false}
-                reorderable={reorderable}
-                isMobile={isMobile}
-                listId={listId}
-                shuffle={shuffle}
-                onDragStart={(event) => handleDragStart(event, index)}
-                onMove={(direction) => moveItem(index, direction)}
-              />
-            </li>
-          ))}
+          {videos.map((video, index) => {
+            const isCurrent = index === currentIndex;
+
+            return (
+              <li
+                key={video.key}
+                ref={(element) => {
+                  register(video.key, element);
+                  if (isCurrent) currentElement.current = element;
+                }}
+                data-pl-row="true"
+                className={`group flex items-center gap-1 px-1 transition-colors hover:bg-surface-strong/60 ${
+                  overIndex === index && dragIndex !== null ? "ring-1 ring-accent ring-inset" : ""
+                } ${dragIndex === index ? "opacity-40" : ""} ${isCurrent ? "bg-surface-strong" : ""}`}
+                onDragOver={reorderable ? (event) => event.preventDefault() : undefined}
+                onDragEnter={reorderable ? () => setOverIndex(index) : undefined}
+                onDrop={reorderable ? () => handleDrop(index) : undefined}
+                onDragEnd={
+                  reorderable
+                    ? () => {
+                        setDragIndex(null);
+                        setOverIndex(null);
+                      }
+                    : undefined
+                }
+              >
+                <WatchPlaylistRow
+                  video={video}
+                  index={index}
+                  total={videos.length}
+                  isCurrent={isCurrent}
+                  reorderable={reorderable}
+                  isMobile={isMobile}
+                  listId={listId}
+                  shuffle={shuffle}
+                  onDragStart={(event) => handleDragStart(event, index)}
+                  onMove={(direction) => moveItem(index, direction)}
+                />
+              </li>
+            );
+          })}
         </ul>
       )}
     </section>

--- a/apps/web/src/components/watch-playlist-panel.tsx
+++ b/apps/web/src/components/watch-playlist-panel.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Shuffle } from "lucide-react";
-import { type DragEvent, useEffect, useRef, useState } from "react";
+import { type DragEvent, type UIEvent, useEffect, useRef, useState } from "react";
 import { useFlipList } from "../hooks/use-flip-list";
 import { useMobile } from "../hooks/use-mobile";
 import { toPublicWatchParam } from "../lib/watch-url";
@@ -12,6 +12,8 @@ type Props = {
   listId: string;
   currentParam: string;
   shuffle: string | undefined;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void;
   onToggleShuffle: () => void;
   onReorder?: (videos: WatchPlaylistItem[]) => void;
 };
@@ -22,6 +24,8 @@ export function WatchPlaylistPanel({
   listId,
   currentParam,
   shuffle,
+  isLoadingMore = false,
+  onLoadMore,
   onToggleShuffle,
   onReorder,
 }: Props) {
@@ -67,6 +71,12 @@ export function WatchPlaylistPanel({
     next.splice(target, 0, moved);
     commit(next);
   }
+  function handleScroll(event: UIEvent<HTMLUListElement>) {
+    if (!onLoadMore || isLoadingMore) return;
+    const list = event.currentTarget;
+    const remaining = list.scrollHeight - list.scrollTop - list.clientHeight;
+    if (remaining < 480) onLoadMore();
+  }
 
   return (
     <section className="overflow-hidden rounded-xl border border-border bg-surface">
@@ -105,7 +115,7 @@ export function WatchPlaylistPanel({
         </button>
       </div>
       {!collapsed && (
-        <ul className="max-h-[24rem] list-none overflow-y-auto py-1">
+        <ul className="max-h-[24rem] list-none overflow-y-auto py-1" onScroll={handleScroll}>
           {videos.map((video, index) => {
             const isCurrent = index === currentIndex;
 

--- a/apps/web/src/components/watch-secondary-content.tsx
+++ b/apps/web/src/components/watch-secondary-content.tsx
@@ -20,11 +20,16 @@ export function WatchSecondaryContent({
   playlistPanel,
   onSeekTimestamp,
 }: Props) {
+  const hasPlaylistPanel = Boolean(playlistPanel);
+  const hasRelatedStreams = relatedStreams.length > 0;
+
   if (!cinemaMode) {
+    if (!(hasPlaylistPanel || hasRelatedStreams)) return null;
+
     return (
       <div className="w-full lg:flex-1 lg:min-w-64 flex flex-col gap-6">
         {playlistPanel}
-        <RelatedVideos streams={relatedStreams} />
+        {hasRelatedStreams && <RelatedVideos streams={relatedStreams} />}
       </div>
     );
   }
@@ -34,10 +39,12 @@ export function WatchSecondaryContent({
       <div className="min-w-0 flex-[2] max-w-[1200px] flex flex-col gap-4">
         <WatchMeta stream={stream} showComments={showComments} onSeekTimestamp={onSeekTimestamp} />
       </div>
-      <div className="w-full lg:flex-1 lg:min-w-64 flex flex-col gap-6">
-        {playlistPanel}
-        <RelatedVideos streams={relatedStreams} />
-      </div>
+      {(hasPlaylistPanel || hasRelatedStreams) && (
+        <div className="w-full lg:flex-1 lg:min-w-64 flex flex-col gap-6">
+          {playlistPanel}
+          {hasRelatedStreams && <RelatedVideos streams={relatedStreams} />}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/hooks/use-saved-playlists.ts
+++ b/apps/web/src/hooks/use-saved-playlists.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  deleteSavedPlaylist,
+  fetchSavedPlaylists,
+  savePublicPlaylist,
+} from "../lib/api-saved-playlists";
+import { playlistListId } from "../lib/playlist-url";
+import type { SavedPlaylistItem } from "../types/playlist";
+import { useAuth } from "./use-auth";
+
+const KEY = ["saved-playlists"];
+
+function samePlaylist(item: SavedPlaylistItem, url: string): boolean {
+  const listId = playlistListId(url) ?? url;
+  return (
+    item.url === url || item.publicPlaylistId === listId || playlistListId(item.url) === listId
+  );
+}
+
+export function useSavedPlaylists() {
+  const qc = useQueryClient();
+  const { authReady, isAuthed } = useAuth();
+  const query = useQuery({
+    queryKey: KEY,
+    queryFn: fetchSavedPlaylists,
+    enabled: authReady && isAuthed,
+  });
+  const save = useMutation({
+    mutationFn: savePublicPlaylist,
+    onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+  });
+  const remove = useMutation({
+    mutationFn: deleteSavedPlaylist,
+    onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+  });
+  const items = query.data ?? [];
+
+  return {
+    query,
+    items,
+    save,
+    remove,
+    findSaved: (url: string) => items.find((item) => samePlaylist(item, url)),
+  };
+}

--- a/apps/web/src/hooks/use-settings.ts
+++ b/apps/web/src/hooks/use-settings.ts
@@ -28,6 +28,7 @@ const DEFAULTS: SettingsItem = {
   sponsorBlockManualSkipOnFullVideo: true,
   sponsorBlockSkipNonMusicOnlyOnMusicVideos: false,
   sponsorBlockMuteInsteadOfSkip: false,
+  hideContinueWatching: false,
   hideHomeRecommendations: false,
   hideRelatedVideos: false,
   hideComments: false,
@@ -50,7 +51,8 @@ export function useSettings() {
 
   const update = useMutation({
     mutationFn: (patch: Partial<SettingsItem>) => {
-      const current = qc.getQueryData<SettingsItem>(KEY) ?? DEFAULTS;
+      const stored = qc.getQueryData<SettingsItem>(KEY);
+      const current = stored ? { ...DEFAULTS, ...stored } : DEFAULTS;
       const next = { ...current, ...patch };
       if (!isAuthed) return Promise.resolve(next);
       return updateSettings(next);
@@ -63,5 +65,7 @@ export function useSettings() {
     },
   });
 
-  return { query, update, settings: query.data ?? DEFAULTS, settingsReady };
+  const settings = query.data ? { ...DEFAULTS, ...query.data } : DEFAULTS;
+
+  return { query, update, settings, settingsReady };
 }

--- a/apps/web/src/hooks/use-watch-ended-navigation.ts
+++ b/apps/web/src/hooks/use-watch-ended-navigation.ts
@@ -1,0 +1,36 @@
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+import type { VideoStream } from "../types/stream";
+
+type Params = {
+  settingsReady: boolean;
+  autoplay: boolean;
+  hideRelatedVideos: boolean;
+  nextParam: string | null;
+  list?: string;
+  shuffle?: string;
+  related?: VideoStream[];
+};
+
+export function useWatchEndedNavigation({
+  settingsReady,
+  autoplay,
+  hideRelatedVideos,
+  nextParam,
+  list,
+  shuffle,
+  related,
+}: Params) {
+  const navigate = useNavigate();
+
+  return useCallback(() => {
+    if (!settingsReady || !autoplay) return;
+    if (nextParam) {
+      navigate({ to: "/watch", search: { v: nextParam, list, ...(shuffle ? { shuffle } : {}) } });
+      return;
+    }
+    if (hideRelatedVideos) return;
+    const next = related?.[0];
+    if (next) navigate({ to: "/watch", search: { v: next.id } });
+  }, [settingsReady, autoplay, nextParam, list, shuffle, hideRelatedVideos, related, navigate]);
+}

--- a/apps/web/src/hooks/use-watch-playlist.tsx
+++ b/apps/web/src/hooks/use-watch-playlist.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router";
-import type { ReactNode } from "react";
+import { type ReactNode, useCallback, useEffect } from "react";
 import { WatchPlaylistPanel } from "../components/watch-playlist-panel";
 import { applyCustomOrder, randomShuffleSeed, shuffleByKey } from "../lib/playlist-shuffle";
 import { isManagedPlaylistId } from "../lib/playlist-url";
@@ -8,6 +8,9 @@ import { usePlaylistOrderStore } from "../stores/playlist-order-store";
 import type { WatchPlaylistItem } from "../types/playlist";
 import { usePlaylist, usePlaylists } from "./use-playlists";
 import { usePublicPlaylist } from "./use-public-playlist";
+
+const MISSING_CURRENT_PREFETCH_LIMIT = 5;
+const PREFETCH_REMAINING_ITEMS = 10;
 
 type WatchPlaylist = {
   nextParam: string | null;
@@ -53,8 +56,27 @@ export function useWatchPlaylist(
   const currentIdx = inPlaylist
     ? videos.findIndex((video) => toPublicWatchParam(video.url) === currentParam)
     : -1;
+  const loadedPublicPageCount = publicPlaylist.data?.pages.length ?? 0;
+  const canLoadPublicPage =
+    !isManaged && Boolean(publicPlaylist.hasNextPage) && !publicPlaylist.isFetchingNextPage;
+  const loadMorePublic = useCallback(() => {
+    if (canLoadPublicPage) void publicPlaylist.fetchNextPage();
+  }, [canLoadPublicPage, publicPlaylist.fetchNextPage]);
   const nextVideo = currentIdx >= 0 ? videos[currentIdx + 1] : undefined;
   const nextParam = nextVideo ? toPublicWatchParam(nextVideo.url) : null;
+
+  useEffect(() => {
+    if (!canLoadPublicPage || videos.length === 0) return;
+    const missingCurrent = currentIdx < 0 && loadedPublicPageCount < MISSING_CURRENT_PREFETCH_LIMIT;
+    const nearEnd = currentIdx >= 0 && currentIdx >= videos.length - PREFETCH_REMAINING_ITEMS;
+    if (missingCurrent || nearEnd) void publicPlaylist.fetchNextPage();
+  }, [
+    canLoadPublicPage,
+    currentIdx,
+    loadedPublicPageCount,
+    videos.length,
+    publicPlaylist.fetchNextPage,
+  ]);
 
   const panel =
     inPlaylist && list ? (
@@ -64,6 +86,8 @@ export function useWatchPlaylist(
         listId={list}
         currentParam={currentParam}
         shuffle={shuffle}
+        isLoadingMore={publicPlaylist.isFetchingNextPage}
+        onLoadMore={canLoadPublicPage ? loadMorePublic : undefined}
         onToggleShuffle={() =>
           navigate({
             to: "/watch",

--- a/apps/web/src/lib/api-saved-playlists.ts
+++ b/apps/web/src/lib/api-saved-playlists.ts
@@ -1,0 +1,26 @@
+import type { SavedPlaylistItem } from "../types/playlist";
+import { ApiError } from "./api";
+import { authed, authedJson } from "./authed";
+import { API_BASE as BASE } from "./env";
+
+export function fetchSavedPlaylists(): Promise<SavedPlaylistItem[]> {
+  return authedJson(`${BASE}/saved-playlists`);
+}
+
+export function savePublicPlaylist(url: string): Promise<SavedPlaylistItem> {
+  return authedJson(`${BASE}/saved-playlists`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+}
+
+export async function deleteSavedPlaylist(id: string): Promise<void> {
+  const res = await authed(`${BASE}/saved-playlists/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok && res.status !== 404) {
+    const body = await res.json().catch(() => ({ error: "delete failed" }));
+    throw new ApiError((body as { error: string }).error, res.status);
+  }
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { createRootRoute, Outlet, useRouterState } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { MobileTabBar } from "../components/mobile-tab-bar";
 import { Navbar } from "../components/navbar";
 import { Sidebar } from "../components/sidebar";
@@ -30,6 +30,7 @@ function AuthShell() {
 function RootLayout() {
   const isMobile = useMobile();
   const collapsed = useUiStore((s) => s.sidebarCollapsed);
+  const setSidebarCollapsed = useUiStore((s) => s.setSidebarCollapsed);
   const closeMobileSidebar = useUiStore((s) => s.closeMobileSidebar);
   const theme = useThemeStore((s) => s.theme);
   const cinemaMode = useWatchLayoutStore((s) => s.cinemaMode);
@@ -39,6 +40,7 @@ function RootLayout() {
   const pathWithSearch = `${pathname}${location.searchStr}`;
   const shortsPage = pathname === "/shorts";
   const watchCinemaPage = pathname === "/watch" && cinemaMode;
+  const wasWatchCinemaPage = useRef(watchCinemaPage);
   useSessionActivityReporting();
 
   useEffect(() => {
@@ -58,6 +60,13 @@ function RootLayout() {
   useEffect(() => {
     if (!isMobile) closeMobileSidebar();
   }, [isMobile, closeMobileSidebar]);
+
+  useLayoutEffect(() => {
+    if (watchCinemaPage && !wasWatchCinemaPage.current && !isMobile) {
+      setSidebarCollapsed(true);
+    }
+    wasWatchCinemaPage.current = watchCinemaPage;
+  }, [watchCinemaPage, isMobile, setSidebarCollapsed]);
 
   useEffect(() => {
     if (status === "loading") return;
@@ -117,7 +126,7 @@ function RootLayout() {
   return (
     <div className="min-h-screen bg-app text-fg">
       <Navbar />
-      {!watchCinemaPage && <Sidebar />}
+      {watchCinemaPage ? !isMobile && <Sidebar overlay /> : <Sidebar />}
       <main className={mainClasses} style={topPadding}>
         <Outlet />
       </main>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -49,7 +49,7 @@ function HomePage() {
 
   return (
     <div className="flex flex-col gap-6 sm:gap-8">
-      <ContinueWatching />
+      {!settings.hideContinueWatching && <ContinueWatching />}
       {showRecommendations && (
         <section className="flex flex-col gap-3">
           <p className="text-xs font-medium uppercase tracking-wider text-fg-soft">{title}</p>

--- a/apps/web/src/routes/playlist.tsx
+++ b/apps/web/src/routes/playlist.tsx
@@ -1,28 +1,42 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { BookmarkCheck, BookmarkPlus } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import { PlaylistActions } from "../components/playlist-actions";
 import { PublicPlaylistHeader } from "../components/public-playlist-header";
 import { ScrollSentinel } from "../components/scroll-sentinel";
+import { Toast } from "../components/toast";
 import { VideoGrid } from "../components/video-grid";
 import { VideoGridSkeleton } from "../components/video-grid-skeleton";
 import { useBlockedFilter } from "../hooks/use-blocked-filter";
 import { usePublicPlaylist } from "../hooks/use-public-playlist";
+import { useSavedPlaylists } from "../hooks/use-saved-playlists";
 import { randomShuffleSeed, shuffleByKey } from "../lib/playlist-shuffle";
+import { playlistListId } from "../lib/playlist-url";
 import { toPublicWatchParam } from "../lib/watch-url";
 
 function PublicPlaylistPage() {
-  const { list } = Route.useSearch();
-  const playlistUrl = list ? `https://www.youtube.com/playlist?list=${list}` : "";
+  const { list, url } = Route.useSearch();
+  const playlistUrl = url || (list ? `https://www.youtube.com/playlist?list=${list}` : "");
+  const listId = list || playlistListId(playlistUrl) || undefined;
   const { data, isLoading, isError, isFetchingNextPage, hasNextPage, fetchNextPage } =
     usePublicPlaylist(playlistUrl);
+  const savedPlaylists = useSavedPlaylists();
   const { filter } = useBlockedFilter();
   const navigate = useNavigate();
+  const [toast, setToast] = useState<string | null>(null);
+  const saved = savedPlaylists.findSaved(playlistUrl);
 
   const loadMore = useCallback(() => {
     if (hasNextPage && !isFetchingNextPage) fetchNextPage();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  if (!list) return <p className="text-fg-muted text-sm">No playlist selected.</p>;
+  useEffect(() => {
+    if (!toast) return;
+    const timer = setTimeout(() => setToast(null), 2500);
+    return () => clearTimeout(timer);
+  }, [toast]);
+
+  if (!playlistUrl) return <p className="text-fg-muted text-sm">No playlist selected.</p>;
   if (isLoading) return <VideoGridSkeleton idPrefix="public-playlist" />;
   if (isError || !data) {
     return (
@@ -41,8 +55,20 @@ function PublicPlaylistPage() {
     if (!url) return;
     navigate({
       to: "/watch",
-      search: { v: toPublicWatchParam(url), list, ...(shuffle ? { shuffle } : {}) },
+      search: {
+        v: toPublicWatchParam(url),
+        ...(listId ? { list: listId } : {}),
+        ...(shuffle ? { shuffle } : {}),
+      },
     });
+  }
+
+  function toggleSaved() {
+    if (saved) {
+      savedPlaylists.remove.mutate(saved.id, { onSuccess: () => setToast("Playlist removed") });
+      return;
+    }
+    savedPlaylists.save.mutate(playlistUrl, { onSuccess: () => setToast("Playlist saved") });
   }
 
   return (
@@ -50,22 +76,38 @@ function PublicPlaylistPage() {
       <div className="flex flex-wrap items-start justify-between gap-3">
         {info && <PublicPlaylistHeader info={info} />}
         {streams.length > 0 && (
-          <PlaylistActions
-            onPlayAll={() => playFrom(streams[0]?.id)}
-            onShuffle={() => {
-              const seed = randomShuffleSeed();
-              playFrom(shuffleByKey(streams, seed)[0]?.id, seed);
-            }}
-          />
+          <div className="flex flex-wrap items-center gap-2">
+            <PlaylistActions
+              onPlayAll={() => playFrom(streams[0]?.id)}
+              onShuffle={() => {
+                const seed = randomShuffleSeed();
+                playFrom(shuffleByKey(streams, seed)[0]?.id, seed);
+              }}
+            />
+            <button
+              type="button"
+              onClick={toggleSaved}
+              disabled={savedPlaylists.save.isPending || savedPlaylists.remove.isPending}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border-strong px-3 py-1.5 font-medium text-fg text-xs transition-colors hover:bg-surface-strong disabled:opacity-50"
+            >
+              {saved ? (
+                <BookmarkCheck className="h-3.5 w-3.5" />
+              ) : (
+                <BookmarkPlus className="h-3.5 w-3.5" />
+              )}
+              {saved ? "Saved" : "Save"}
+            </button>
+          </div>
         )}
       </div>
       {streams.length === 0 ? (
         <p className="text-fg-muted text-sm">This playlist has no videos.</p>
       ) : (
-        <VideoGrid streams={streams} listId={list} />
+        <VideoGrid streams={streams} listId={listId} />
       )}
       {isFetchingNextPage && <VideoGridSkeleton idPrefix="public-playlist-next" />}
       <ScrollSentinel onIntersect={loadMore} enabled={!!hasNextPage && !isFetchingNextPage} />
+      <Toast message={toast} />
     </div>
   );
 }
@@ -73,6 +115,7 @@ function PublicPlaylistPage() {
 export const Route = createFileRoute("/playlist")({
   validateSearch: (search: Record<string, unknown>) => ({
     list: typeof search.list === "string" ? search.list : "",
+    url: typeof search.url === "string" ? search.url : "",
   }),
   component: PublicPlaylistPage,
 });

--- a/apps/web/src/routes/playlist.tsx
+++ b/apps/web/src/routes/playlist.tsx
@@ -114,8 +114,8 @@ function PublicPlaylistPage() {
 
 export const Route = createFileRoute("/playlist")({
   validateSearch: (search: Record<string, unknown>) => ({
-    list: typeof search.list === "string" ? search.list : "",
-    url: typeof search.url === "string" ? search.url : "",
+    list: typeof search.list === "string" && search.list.length > 0 ? search.list : undefined,
+    url: typeof search.url === "string" && search.url.length > 0 ? search.url : undefined,
   }),
   component: PublicPlaylistPage,
 });

--- a/apps/web/src/routes/playlists.tsx
+++ b/apps/web/src/routes/playlists.tsx
@@ -4,28 +4,27 @@ import { ConfirmModal } from "../components/confirm-modal";
 import { LibraryCollectionCard } from "../components/library-collection-card";
 import { PlaylistCard } from "../components/playlist-card";
 import { PlaylistCreateModal } from "../components/playlist-create-modal";
+import { PlaylistsEmptyState } from "../components/playlists-empty-state";
+import { PlaylistsPageHeader } from "../components/playlists-page-header";
+import { SavedPlaylistsSection } from "../components/saved-playlists-section";
 import { Toast } from "../components/toast";
 import { useFavoriteStreams } from "../hooks/use-favorite-streams";
 import { usePlaylists } from "../hooks/use-playlists";
+import { useSavedPlaylists } from "../hooks/use-saved-playlists";
 import { useWatchLaterStreams } from "../hooks/use-watch-later-streams";
-
-function EmptyState() {
-  return (
-    <div className="flex flex-col items-center justify-center py-32 gap-2 text-center">
-      <p className="text-fg-muted text-sm">No playlists yet.</p>
-      <p className="text-fg-soft text-xs">Use the New playlist button to get started.</p>
-    </div>
-  );
-}
+import type { SavedPlaylistItem } from "../types/playlist";
 
 function PlaylistsPage() {
   const { query, create, remove } = usePlaylists();
+  const savedPlaylists = useSavedPlaylists();
   const favorites = useFavoriteStreams({ limit: 1 });
   const watchLater = useWatchLaterStreams();
   const playlists = query.data ?? [];
+  const saved = savedPlaylists.items;
   const [selectionMode, setSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [confirmIds, setConfirmIds] = useState<string[] | null>(null);
+  const [savedConfirm, setSavedConfirm] = useState<SavedPlaylistItem | null>(null);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
 
@@ -58,62 +57,36 @@ function PlaylistsPage() {
     setToastMsg(count === 1 ? "Playlist deleted" : `${count} playlists deleted`);
   }
 
+  function handleSavedConfirm() {
+    if (!savedConfirm) return;
+    savedPlaylists.remove.mutate(savedConfirm.id);
+    setToastMsg(`Removed ${savedConfirm.title}`);
+    setSavedConfirm(null);
+  }
+
   const confirmTitle =
     confirmIds === null
       ? ""
       : confirmIds.length === 1
         ? `Delete "${playlists.find((p) => p.id === confirmIds[0])?.name ?? "this playlist"}"?`
         : `Delete ${confirmIds.length} playlists?`;
+  const hasLocalCollections = playlists.length > 0 || favorites.count > 0 || watchLater.count > 0;
 
   return (
     <div className="flex flex-col gap-6 [animation:page-fade-in_0.2s_ease-out]">
-      <div className="flex items-center justify-between flex-wrap gap-3">
-        <h1 className="text-lg font-semibold text-fg">Playlists</h1>
-        <div className="flex items-center gap-2">
-          {selectionMode ? (
-            <>
-              <span className="text-xs text-fg-soft">{selectedIds.size} selected</span>
-              <button
-                type="button"
-                onClick={exitSelection}
-                className="px-3 py-2 text-sm text-fg-muted bg-surface-strong hover:bg-surface-soft rounded-lg transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                disabled={selectedIds.size === 0}
-                onClick={() => setConfirmIds([...selectedIds])}
-                className="px-3 py-2 text-sm text-white bg-danger hover:bg-danger disabled:opacity-40 disabled:cursor-not-allowed rounded-lg transition-colors"
-              >
-                Delete ({selectedIds.size})
-              </button>
-            </>
-          ) : (
-            <>
-              {playlists.length > 0 && (
-                <button
-                  type="button"
-                  onClick={() => setSelectionMode(true)}
-                  className="px-3 py-2 text-sm text-fg-muted hover:text-fg bg-surface-strong hover:bg-surface-soft rounded-lg transition-colors"
-                >
-                  Select
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={() => setCreating(true)}
-                className="px-3 py-2 text-sm text-fg bg-surface-strong hover:bg-surface-soft rounded-lg transition-colors"
-              >
-                New playlist
-              </button>
-            </>
-          )}
-        </div>
-      </div>
-      {playlists.length === 0 && favorites.count === 0 && watchLater.count === 0 ? (
-        <EmptyState />
-      ) : (
+      <PlaylistsPageHeader
+        selectionMode={selectionMode}
+        selectedCount={selectedIds.size}
+        canSelect={playlists.length > 0}
+        onSelect={() => setSelectionMode(true)}
+        onCancel={exitSelection}
+        onDelete={() => setConfirmIds([...selectedIds])}
+        onCreate={() => setCreating(true)}
+      />
+      <SavedPlaylistsSection playlists={saved} onDelete={setSavedConfirm} />
+      {!hasLocalCollections && saved.length === 0 ? (
+        <PlaylistsEmptyState />
+      ) : hasLocalCollections ? (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
           <LibraryCollectionCard
             kind="favorites"
@@ -143,7 +116,7 @@ function PlaylistsPage() {
             </div>
           ))}
         </div>
-      )}
+      ) : null}
       {creating && (
         <PlaylistCreateModal
           onConfirm={(name) => {
@@ -160,6 +133,14 @@ function PlaylistsPage() {
           description="This action cannot be undone."
           onConfirm={handleConfirm}
           onCancel={() => setConfirmIds(null)}
+        />
+      )}
+      {savedConfirm !== null && (
+        <ConfirmModal
+          title={`Remove "${savedConfirm.title}"?`}
+          description="This only removes the saved reference from your library."
+          onConfirm={handleSavedConfirm}
+          onCancel={() => setSavedConfirm(null)}
         />
       )}
       <Toast message={toastMsg} />

--- a/apps/web/src/settings/settings-content-toggles.tsx
+++ b/apps/web/src/settings/settings-content-toggles.tsx
@@ -5,7 +5,12 @@ const ROW = "flex items-center justify-between gap-4 px-4 py-4";
 
 type ToggleKey = Extract<
   keyof SettingsItem,
-  "autoplay" | "hideHomeRecommendations" | "hideRelatedVideos" | "hideComments" | "hideShorts"
+  | "autoplay"
+  | "hideContinueWatching"
+  | "hideHomeRecommendations"
+  | "hideRelatedVideos"
+  | "hideComments"
+  | "hideShorts"
 >;
 
 type ToggleOption = {
@@ -37,6 +42,12 @@ const WATCH_OPTIONS: ToggleOption[] = [
 ];
 
 const DISCOVERY_OPTIONS: ToggleOption[] = [
+  {
+    key: "hideContinueWatching",
+    label: "Continue watching",
+    description: "Hide in-progress videos from the home page.",
+    area: "Home",
+  },
   {
     key: "hideHomeRecommendations",
     label: "Home recommendations",

--- a/apps/web/src/stores/ui-store.ts
+++ b/apps/web/src/stores/ui-store.ts
@@ -4,6 +4,7 @@ import { persist } from "zustand/middleware";
 type UiStore = {
   sidebarCollapsed: boolean;
   mobileSidebarOpen: boolean;
+  setSidebarCollapsed: (value: boolean) => void;
   toggleSidebar: () => void;
   openMobileSidebar: () => void;
   closeMobileSidebar: () => void;
@@ -15,6 +16,7 @@ export const useUiStore = create<UiStore>()(
     (set) => ({
       sidebarCollapsed: false,
       mobileSidebarOpen: false,
+      setSidebarCollapsed: (value) => set({ sidebarCollapsed: value }),
       toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
       openMobileSidebar: () => set({ mobileSidebarOpen: true }),
       closeMobileSidebar: () => set({ mobileSidebarOpen: false }),

--- a/apps/web/src/types/playlist.ts
+++ b/apps/web/src/types/playlist.ts
@@ -26,6 +26,18 @@ export type PublicPlaylistResponse = {
   nextpage: string | null;
 };
 
+export type SavedPlaylistItem = {
+  id: string;
+  publicPlaylistId: string;
+  url: string;
+  title: string;
+  thumbnailUrl: string;
+  uploaderName: string;
+  streamCount: number;
+  playlistType: string;
+  savedAt: number;
+};
+
 export type ChannelPlaylistsResponse = {
   playlists: PublicPlaylistInfo[];
   nextpage: string | null;

--- a/apps/web/src/types/user.ts
+++ b/apps/web/src/types/user.ts
@@ -102,6 +102,7 @@ export type SettingsItem = {
   sponsorBlockManualSkipOnFullVideo: boolean;
   sponsorBlockSkipNonMusicOnlyOnMusicVideos: boolean;
   sponsorBlockMuteInsteadOfSkip: boolean;
+  hideContinueWatching: boolean;
   hideHomeRecommendations: boolean;
   hideRelatedVideos: boolean;
   hideComments: boolean;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,16 +13,29 @@ services:
     image: ghcr.io/priveetee/typetype-server:latest
     ports:
       - "${HOST_PORT_SERVER:-8080}:8080"
-    env_file: .env
     environment:
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:8082,http://127.0.0.1:8082,http://localhost:5173,http://127.0.0.1:5173}
+      DATABASE_URL: ${DATABASE_URL:-jdbc:postgresql://postgres:5432/typetype}
+      DATABASE_USER: ${DATABASE_USER:-typetype}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD:-typetype}
+      DRAGONFLY_URL: ${DRAGONFLY_URL:-redis://dragonfly:6379}
+      GITHUB_REPO: ${GITHUB_REPO:-Priveetee/TypeType-Server}
+      GITHUB_ISSUE_TEMPLATE: ${GITHUB_ISSUE_TEMPLATE:-bug_report_backend.md}
       DOWNLOADER_SERVICE_URL: http://typetype-downloader:18093
       YOUTUBE_REMOTE_LOGIN_SERVICE_URL: http://typetype-token:8081
       YOUTUBE_REMOTE_LOGIN_CALLBACK_BASE_URL: http://typetype-server:8080
       YOUTUBE_REMOTE_LOGIN_INTERNAL_TOKEN: ${YOUTUBE_REMOTE_LOGIN_INTERNAL_TOKEN:-}
+      YOUTUBE_REMOTE_LOGIN_INTERNAL_TOKEN_FILE: /run/typetype-secrets/youtube_remote_login_internal_token
+      YOUTUBE_SESSION_ENCRYPTION_KEY: ${YOUTUBE_SESSION_ENCRYPTION_KEY:-}
+      YOUTUBE_SESSION_ENCRYPTION_KEY_FILE: /run/typetype-secrets/youtube_session_encryption_key
       YOUTUBE_REMOTE_LOGIN_TTL_MS: ${YOUTUBE_REMOTE_LOGIN_TTL_MS:-480000}
       YOUTUBE_REMOTE_LOGIN_MAX_SESSIONS: ${YOUTUBE_REMOTE_LOGIN_MAX_SESSIONS:-2}
       YOUTUBE_REMOTE_LOGIN_MAX_FRAME_BYTES: ${YOUTUBE_REMOTE_LOGIN_MAX_FRAME_BYTES:-524288}
+    volumes:
+      - typetype_secrets:/run/typetype-secrets:ro
     depends_on:
+      typetype-secrets:
+        condition: service_completed_successfully
       postgres-init:
         condition: service_completed_successfully
       dragonfly:
@@ -32,6 +45,29 @@ services:
       typetype-downloader:
         condition: service_started
     restart: unless-stopped
+
+  typetype-secrets:
+    image: busybox:1.37
+    command:
+      - /bin/sh
+      - -ec
+      - |
+        generate_secret() {
+          dd if=/dev/urandom bs=48 count=1 2>/dev/null | base64 | tr '+/' '-_' | tr -d '=\n'
+        }
+        ensure_secret() {
+          file="$$1"
+          if [ ! -s "$$file" ]; then
+            generate_secret > "$$file"
+          fi
+          chmod 0444 "$$file"
+        }
+        mkdir -p /run/typetype-secrets
+        ensure_secret /run/typetype-secrets/youtube_remote_login_internal_token
+        ensure_secret /run/typetype-secrets/youtube_session_encryption_key
+    volumes:
+      - typetype_secrets:/run/typetype-secrets
+    restart: "no"
 
   typetype-downloader:
     image: ghcr.io/priveetee/typetype-downloader:latest
@@ -57,8 +93,8 @@ services:
       S3_PUBLIC_ENDPOINT: ${DOWNLOADER_S3_PUBLIC_ENDPOINT:-}
       S3_REGION: garage
       S3_BUCKET: typetype-downloads
-      S3_ACCESS_KEY: ${DOWNLOADER_S3_ACCESS_KEY}
-      S3_SECRET_KEY: ${DOWNLOADER_S3_SECRET_KEY}
+      S3_ACCESS_KEY: ${DOWNLOADER_S3_ACCESS_KEY:-}
+      S3_SECRET_KEY: ${DOWNLOADER_S3_SECRET_KEY:-}
       S3_ARTIFACT_TTL_SECONDS: "7200"
     depends_on:
       postgres-init:
@@ -79,12 +115,18 @@ services:
     ipc: host
     environment:
       NODE_ENV: production
-      YOUTUBE_REMOTE_LOGIN_ENABLED: ${YOUTUBE_REMOTE_LOGIN_ENABLED:-false}
+      YOUTUBE_REMOTE_LOGIN_ENABLED: ${YOUTUBE_REMOTE_LOGIN_ENABLED:-true}
       YOUTUBE_REMOTE_LOGIN_INTERNAL_TOKEN: ${YOUTUBE_REMOTE_LOGIN_INTERNAL_TOKEN:-}
+      YOUTUBE_REMOTE_LOGIN_INTERNAL_TOKEN_FILE: /run/typetype-secrets/youtube_remote_login_internal_token
       YOUTUBE_REMOTE_LOGIN_CALLBACK_ORIGIN: ${YOUTUBE_REMOTE_LOGIN_CALLBACK_ORIGIN:-http://typetype-server:8080}
       YOUTUBE_REMOTE_LOGIN_MAX_SESSIONS: ${YOUTUBE_REMOTE_LOGIN_MAX_SESSIONS:-2}
       YOUTUBE_REMOTE_LOGIN_FRAME_FPS: ${YOUTUBE_REMOTE_LOGIN_FRAME_FPS:-10}
       YOUTUBE_REMOTE_LOGIN_MAX_FRAME_BYTES: ${YOUTUBE_REMOTE_LOGIN_MAX_FRAME_BYTES:-524288}
+    volumes:
+      - typetype_secrets:/run/typetype-secrets:ro
+    depends_on:
+      typetype-secrets:
+        condition: service_completed_successfully
     restart: unless-stopped
 
   postgres:
@@ -133,5 +175,6 @@ services:
 
 volumes:
   postgres_data:
+  typetype_secrets:
   garage_meta:
   garage_data:


### PR DESCRIPTION
## Summary
- make the compose stack generate remote login secrets in a persistent Docker volume
- mount generated secrets into Server and Token as read-only files
- remove the hard dependency on a local `.env` file for Server runtime defaults
- enable the internal Token remote-login service by default while keeping the admin toggle on Server

## Production behavior
- Portainer and homelab users can paste the compose file without cloning the repository or running scripts
- the `typetype-secrets` init container exits after creating missing secrets; `Exited (0)` is expected
- existing real `.env` values keep priority over generated files
- this compose change must ship with the matching Server and Token image changes

## Verification
- `docker compose -f docker-compose.yml config`
- compose config validation without `.env`
- BusyBox secret generation smoke: two 64-character secret files created in a Docker volume
- `git diff --check`
- dev branch checks passed: Coverage, CI, Docker

## Rollback
- restore the previous compose file if stack startup regresses
- the generated Docker volume can stay in place; existing `.env` secrets remain supported
