### PR TITLE
Update DB_URL format in downloader

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,7 +41,7 @@ services:
       HTTP_PORT: "18093"
       PUBLIC_BASE_URL: /api/downloader
       TYPETYPE_API_BASE: http://typetype-server:8080
-      DB_URL: jdbc:postgresql://postgres:5432/typetype_downloader
+      DB_URL: postgres://${DATABASE_USER:-typetype}:${DATABASE_PASSWORD:-typetype}@postgres:5432/typetype_downloader
       DB_USER: typetype
       DB_PASSWORD: typetype
       REDIS_HOST: dragonfly

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,9 +41,7 @@ services:
       HTTP_PORT: "18093"
       PUBLIC_BASE_URL: /api/downloader
       TYPETYPE_API_BASE: http://typetype-server:8080
-      DB_URL: postgres://${DATABASE_USER:-typetype}:${DATABASE_PASSWORD:-typetype}@postgres:5432/typetype_downloader
-      DB_USER: typetype
-      DB_PASSWORD: typetype
+      DB_URL: postgres://typetype:typetype@postgres:5432/typetype_downloader?sslmode=disable
       REDIS_HOST: dragonfly
       REDIS_PORT: "6379"
       REDIS_QUEUE_KEY: downloader:queue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,9 +75,7 @@ services:
       HTTP_PORT: "18093"
       PUBLIC_BASE_URL: /api/downloader
       TYPETYPE_API_BASE: http://typetype-server:8080
-      DB_URL: postgres://${DATABASE_USER:-typetype}:${DATABASE_PASSWORD:-typetype}@postgres:5432/typetype_downloader
-      DB_USER: typetype
-      DB_PASSWORD: typetype
+      DB_URL: postgres://typetype:typetype@postgres:5432/typetype_downloader?sslmode=disable
       REDIS_HOST: dragonfly
       REDIS_PORT: "6379"
       REDIS_QUEUE_KEY: downloader:queue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       HTTP_PORT: "18093"
       PUBLIC_BASE_URL: /api/downloader
       TYPETYPE_API_BASE: http://typetype-server:8080
-      DB_URL: jdbc:postgresql://postgres:5432/typetype_downloader
+      DB_URL: postgres://${DATABASE_USER:-typetype}:${DATABASE_PASSWORD:-typetype}@postgres:5432/typetype_downloader
       DB_USER: typetype
       DB_PASSWORD: typetype
       REDIS_HOST: dragonfly


### PR DESCRIPTION
The DB_URL environment variable passed to typetype-downloader was using a JDBC connection string (jdbc:postgresql://...), but the downloader is a Go service that expects a standard PostgreSQL DSN (postgres://...). This caused the service to crash on startup.