### PR TITLE
fix: update MSE player for safe source buffer cleanup

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typetype/web",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
-    "@typetype/mse": "0.1.30",
+    "@typetype/mse": "0.1.31",
     "@vidstack/react": "1.12.13",
     "dashjs": "^5.2.0",
     "hls.js": "1.6.16",

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-router": "^1.170.17",
-        "@typetype/mse": "0.1.30",
+        "@typetype/mse": "0.1.31",
         "@vidstack/react": "1.12.13",
         "dashjs": "^5.2.0",
         "hls.js": "1.6.16",
@@ -311,7 +311,7 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@typetype/mse": ["@typetype/mse@0.1.30", "", {}, "sha512-QNyCy0gtXEdycSSGnWVURmxcWl8J6R/XxFP+U2Zz1rSY3V7HoIpRPiAnkIccfdAUBqwXnZd9jTfTqnWKQyB2pg=="],
+    "@typetype/mse": ["@typetype/mse@0.1.31", "", {}, "sha512-Ll1g9IRdYT7nm44Tq4D0DhLfAt99takj5AvEQryjF0Drq2nRflwC8NW9cxwazGby9UBTX6ggojPW+ttizzwjyA=="],
 
     "@typetype/web": ["@typetype/web@workspace:apps/web"],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typetype",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",
     "knip": "^6.25.0",


### PR DESCRIPTION
## Summary
- update the web app to `@typetype/mse` 0.1.31
- preserve active asynchronous SourceBuffer removal while clearing or destroying an MSE append queue
- keep append cancellation behavior unchanged so obsolete segment appends still stop promptly
- bump the TypeType release version to 1.0.2

## Production behavior
- rapid seeks and player teardown no longer call `SourceBuffer.abort()` while Chromium is processing `SourceBuffer.remove()`
- SABR session replacement continues to reject obsolete queue work with `AbortError`
- stream selection, playback policy, API contracts and stack configuration are unchanged

## Runtime verification
- Chromium SABR playback completed rapid alternating seeks and player session replacements without a media error
- SourceBuffer instrumentation observed 28 removal operations and zero abort calls during an active removal
- Firefox SABR playback started and completed forward and backward seeks without a page error
- the exact Chromium exception is covered by Player queue clear and destroy regression tests

## Tests
- `bun install --frozen-lockfile`
- `bun audit --audit-level=high`
- `bun run check`
- `bun run test:coverage`
- `bun run knip`
- `bun run sherif`
- `bun run build`
- `git diff --check`

## Rollback
- revert the MSE dependency and version bump if SourceBuffer cleanup or SABR playback regresses
