### PR TITLE
chore: release TypeType 1.0.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,6 +68,18 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "build-time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
+      - name: Validate stable release notes
+        if: github.ref_name == 'main' || startsWith(github.ref, 'refs/tags/v')
+        env:
+          RELEASE_VERSION: ${{ steps.build-info.outputs.version }}
+        run: |
+          expected_heading="# TypeType $RELEASE_VERSION"
+          actual_heading="$(sed -n '1p' RELEASE_NOTES.md)"
+          if [[ "$actual_heading" != "$expected_heading" ]]; then
+            echo "RELEASE_NOTES.md must start with: $expected_heading"
+            exit 1
+          fi
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6.0.0
@@ -420,6 +432,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -441,15 +456,16 @@ jobs:
             exit 0
           fi
           notes_file="$RUNNER_TEMP/release-notes.md"
+          cp RELEASE_NOTES.md "$notes_file"
           {
-            echo "## Release"
+            echo "## Technical details"
             echo
             echo "- Version: \`$RELEASE_VERSION\`"
             echo "- Commit: [\`${REVISION:0:7}\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/commit/$REVISION)"
             echo "- Container image: \`$IMAGE_NAME@$IMAGE_DIGEST\`"
             echo
-            echo "For full release notes, go to [typetype.video/releases](https://typetype.video/releases)."
-          } > "$notes_file"
+            echo "For the complete release history, see [typetype.video/releases](https://typetype.video/releases)."
+          } >> "$notes_file"
           gh release create "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$REVISION" \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -158,15 +158,16 @@ jobs:
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          rm -rf /tmp/typetype-digests
-          mkdir -p /tmp/typetype-digests
-          touch "/tmp/typetype-digests/${DIGEST#sha256:}"
+          digest_dir="$RUNNER_TEMP/typetype-digests"
+          rm -rf "$digest_dir"
+          mkdir -p "$digest_dir"
+          touch "$digest_dir/${DIGEST#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.arch }}
-          path: /tmp/typetype-digests/*
+          path: ${{ runner.temp }}/typetype-digests/*
           if-no-files-found: error
           retention-days: 1
 
@@ -186,12 +187,12 @@ jobs:
 
     steps:
       - name: Prepare digest directory
-        run: rm -rf /tmp/typetype-digests
+        run: rm -rf "$RUNNER_TEMP/typetype-digests"
 
       - name: Download digests
         uses: actions/download-artifact@v8.0.1
         with:
-          path: /tmp/typetype-digests
+          path: ${{ runner.temp }}/typetype-digests
           pattern: digests-*
           merge-multiple: true
 
@@ -208,10 +209,11 @@ jobs:
       - name: Create manifest list and push
         id: manifest
         env:
+          DIGEST_DIR: ${{ runner.temp }}/typetype-digests
           IMAGE: ${{ needs.prepare-image.outputs.image }}
           METADATA_JSON: ${{ needs.prepare-image.outputs.metadata-json }}
-        working-directory: /tmp/typetype-digests
         run: |
+          cd "$DIGEST_DIR"
           mapfile -t digests < <(find . -maxdepth 1 -type f -printf '%f\n' | sort)
           if [[ "${#digests[@]}" -ne 2 ]]; then
             echo "Expected two platform digests, found ${#digests[@]}"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,17 @@
+# TypeType 1.0.2
+
+TypeType 1.0.2 is a stability update for SABR playback. It fixes a Chromium MediaSource failure that could happen during rapid seeks or when replacing an active player session.
+
+## What changed
+
+- Prevent `SourceBuffer.abort()` while an asynchronous removal is active.
+- Improve playback stability during rapid forward and backward seeks.
+- Preserve cancellation of obsolete SABR segment requests.
+- Keep existing API contracts and self-hosting configuration unchanged.
+
+## Updating
+
+Follow the [update guide](https://priveetee.github.io/Docs-TypeType/self-hosting/maintenance).
+
+If necessary, follow the [rollback guide](https://priveetee.github.io/Docs-TypeType/self-hosting/rollback).
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,18 @@
-# TypeType 1.0.2
+# TypeType 1.0.3
 
-TypeType 1.0.2 is a stability update for SABR playback. It fixes a Chromium MediaSource failure that could happen during rapid seeks or when replacing an active player session.
+TypeType 1.0.3 improves the stable release process for self-hosters. GitHub releases now provide concise, human-written notes together with the exact commit and container image used for each release.
 
 ## What changed
 
-- Prevent `SourceBuffer.abort()` while an asynchronous removal is active.
-- Improve playback stability during rapid forward and backward seeks.
-- Preserve cancellation of obsolete SABR segment requests.
-- Keep existing API contracts and self-hosting configuration unchanged.
+- Publish curated notes for stable TypeType releases.
+- Validate that release notes match the version before publishing an image.
+- Include the immutable commit and multi-architecture container digest in every stable release.
+- Keep automatic beta build notes separate from stable release notes.
+
+TypeType runtime behavior, API contracts and self-hosting configuration are unchanged from 1.0.2.
 
 ## Updating
 
 Follow the [update guide](https://priveetee.github.io/Docs-TypeType/self-hosting/maintenance).
 
 If necessary, follow the [rollback guide](https://priveetee.github.io/Docs-TypeType/self-hosting/rollback).
-

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@typetype/web",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typetype",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "devDependencies": {
     "@biomejs/biome": "^2.5.3",
     "knip": "^6.25.0",


### PR DESCRIPTION
## Summary
- require the stable release note heading to match the package version before building or publishing
- append the exact commit and immutable multi-architecture image digest to every stable release
- keep automatic prerelease notes isolated from the stable release narrative
- prepare the root and web packages for TypeType 1.0.3
- isolate platform digest artifacts per self-hosted runner before assembling the final manifest

## Production behavior
- stable GitHub releases now explain the user-facing release instead of showing only generated metadata
- a mismatched version and release note fails before a stable image can be published
- stable releases retain exact commit and container provenance
- concurrent AMD64 and ARM64 builds no longer overwrite each other's digest artifact
- application runtime behavior, API contracts, data and self-hosting configuration are unchanged from 1.0.2

## Deployment requirements
- no database migration, environment change or manual stack edit is required
- merging to `main` builds the stable AMD64/ARM64 image, runs the versioned stable update and health gates, then publishes `v1.0.3`
- update and rollback instructions remain linked directly from the release notes

## Runtime verification
- candidate `v1.0.3-beta.559` completed the full Docker workflow and beta update
- candidate image: `ghcr.io/priveetee/typetype-beta@sha256:41b090549d1c92a63622cd50728e40a06af8a21291238045f2a22edbe3c6b0e1`
- the published manifest contains `linux/amd64` and `linux/arm64`
- both beta health checks passed after the update
- release version `1.0.3` matches the curated release note heading

## Rollback
- retain `v1.0.2` and its immutable image digest as the previous stable release
- follow the documented rollback guide if the stable update or release publication fails


