### PR TITLE
feature: add embeddable video player

### DIFF
--- a/apps/web/src/components/embed-player-shell.tsx
+++ b/apps/web/src/components/embed-player-shell.tsx
@@ -7,7 +7,7 @@ import { useWatchVttAssets } from "../hooks/use-watch-layout-assets";
 import { getOriginalAudioLocale } from "../lib/audio-track";
 import type { VideoStream } from "../types/stream";
 import { toPublicWatchParam } from "../lib/watch-url";
-import { EmbedPlayer } from "./embed-player";
+import { EmbedVideoPlayer } from "./embed-player";
 
 type Props = {
   stream: VideoStream;
@@ -51,7 +51,7 @@ export function EmbedPlayerShell({ stream, sourceUrl, startTime, autoplay, isAut
   ].join(":");
 
   return (
-    <EmbedPlayer
+    <EmbedVideoPlayer
       playerKey={playerKey}
       src={player.manifestSrc}
       sabrConfig={sabrConfig}

--- a/apps/web/src/components/embed-player-shell.tsx
+++ b/apps/web/src/components/embed-player-shell.tsx
@@ -1,0 +1,84 @@
+import { usePlayerError } from "../hooks/use-player-error";
+import { useSabrPlaybackConfig } from "../hooks/use-sabr-playback-config";
+import { useSettings } from "../hooks/use-settings";
+import { useVolumeSync } from "../hooks/use-volume-sync";
+import { useWatchSponsorBlock } from "../hooks/use-watch-sponsorblock";
+import { useWatchVttAssets } from "../hooks/use-watch-layout-assets";
+import { getOriginalAudioLocale } from "../lib/audio-track";
+import type { VideoStream } from "../types/stream";
+import { toPublicWatchParam } from "../lib/watch-url";
+import { EmbedPlayer } from "./embed-player";
+
+type Props = {
+  stream: VideoStream;
+  sourceUrl: string;
+  startTime: number;
+  autoplay: boolean;
+  isAuthed: boolean;
+};
+
+export function EmbedPlayerShell({ stream, sourceUrl, startTime, autoplay, isAuthed }: Props) {
+  const { settings, settingsReady, update } = useSettings();
+  const isLive = stream.streamType === "live_stream" || stream.streamType === "audio_live_stream";
+  const player = usePlayerError(stream, isLive);
+  const handleVolumeChange = useVolumeSync(update.mutate);
+
+  const watchUrl = `/watch?v=${encodeURIComponent(toPublicWatchParam(sourceUrl))}`;
+
+  const sponsor = useWatchSponsorBlock(stream, settings);
+  const autoSkipSponsorBlock = isAuthed && settings.sponsorBlockMode !== "disabled";
+
+  const { thumbnailVtt, chaptersVtt } = useWatchVttAssets(
+    stream,
+    sponsor.segments,
+    settings.sponsorBlockShowChapters,
+  );
+
+  const sabrConfig = useSabrPlaybackConfig(
+    stream,
+    player.sabrEnabled,
+    settings.defaultQuality,
+    settings.defaultAudioLanguage,
+    false,
+  );
+
+  const playerKey = [
+    stream.id,
+    player.retryKey,
+    player.sabrEnabled ? "sabr" : "std",
+    thumbnailVtt ? "thumbs" : "no-thumbs",
+    chaptersVtt ? "chapters" : "no-chapters",
+  ].join(":");
+
+  return (
+    <EmbedPlayer
+      playerKey={playerKey}
+      src={player.manifestSrc}
+      sabrConfig={sabrConfig}
+      audioOnly={false}
+      title={stream.title}
+      poster={stream.thumbnail}
+      subtitles={stream.subtitles}
+      startTime={startTime}
+      autoplay={autoplay}
+      settingsReady={settingsReady}
+      streamType={isLive ? "live" : "on-demand"}
+      chaptersVtt={chaptersVtt}
+      thumbnailVtt={thumbnailVtt}
+      originalAudioLocale={getOriginalAudioLocale(stream)}
+      initialVolume={settings.volume}
+      initialMuted={settings.muted}
+      sponsorBlockSegments={sponsor.segments}
+      autoSkipSponsorBlockSegments={isAuthed ? sponsor.autoSkipSegments : []}
+      manualSkipSponsorBlockSegments={isAuthed ? sponsor.manualSkipSegments : sponsor.segments}
+      autoSkipSponsorBlock={autoSkipSponsorBlock}
+      muteSponsorBlockInsteadOfSkip={settings.sponsorBlockMuteInsteadOfSkip}
+      showCurrentSponsorBlockSegment={settings.sponsorBlockShowCurrentSegment}
+      captionStyles={settings.captionStyles}
+      onCaptionStylesChange={(captionStyles) => update.mutate({ captionStyles })}
+      onVolumeChange={handleVolumeChange}
+      onError={player.handleError}
+      watchUrl={watchUrl}
+    />
+  );
+}

--- a/apps/web/src/components/embed-player.tsx
+++ b/apps/web/src/components/embed-player.tsx
@@ -6,7 +6,7 @@ type Props = VideoPlayerProps & {
   watchUrl?: string;
 };
 
-export function EmbedPlayer({ playerKey, watchUrl, ...props }: Props) {
+export function EmbedVideoPlayer({ playerKey, watchUrl, ...props }: Props) {
   const overlay =
     props.title && watchUrl ? (
       <a

--- a/apps/web/src/components/embed-player.tsx
+++ b/apps/web/src/components/embed-player.tsx
@@ -1,0 +1,30 @@
+import { VideoPlayer } from "./video-player";
+import type { VideoPlayerProps } from "./video-player-types";
+
+type Props = VideoPlayerProps & {
+  playerKey?: string | number;
+  watchUrl?: string;
+};
+
+export function EmbedPlayer({ playerKey, watchUrl, ...props }: Props) {
+  const overlay =
+    props.title && watchUrl ? (
+      <a
+        href={watchUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="absolute top-0 left-0 right-0 z-10 flex items-center gap-2 px-3 py-2 text-sm text-white/90 transition-opacity opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
+        style={{
+          background: "linear-gradient(to bottom, rgba(0,0,0,0.7) 0%, transparent 100%)",
+        }}
+      >
+        <span className="truncate">{props.title}</span>
+      </a>
+    ) : null;
+
+  return (
+    <div className="fixed inset-0 bg-black group">
+      <VideoPlayer key={playerKey} overlay={overlay} {...props} />
+    </div>
+  );
+}

--- a/apps/web/src/lib/playback-mode.ts
+++ b/apps/web/src/lib/playback-mode.ts
@@ -20,7 +20,7 @@ export function readPlaybackMode(): PlaybackMode {
 export function resolveStoredPlaybackMode(stored: string | null): PlaybackMode {
   if (stored === "adaptive") return "sabr";
   if (stored === "ios-legacy-compat") return "legacy";
-  return isPlaybackMode(stored) ? stored : "legacy";
+  return isPlaybackMode(stored) ? stored : "sabr";
 }
 
 export function setPlaybackMode(mode: PlaybackMode): void {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as SubscriptionsChannelsRouteImport } from './routes/subscription
 import { Route as PlaylistsIdRouteImport } from './routes/playlists_.$id'
 import { Route as ImportYoutubeRouteImport } from './routes/import/youtube'
 import { Route as ImportPipepipeRouteImport } from './routes/import/pipepipe'
+import { Route as EmbedVideoIdRouteImport } from './routes/embed_.$videoId'
 import { Route as ChannelChannelIdRouteImport } from './routes/channel_.$channelId'
 import { Route as AuthOidcCallbackRouteImport } from './routes/auth.oidc.callback'
 
@@ -174,6 +175,11 @@ const ImportPipepipeRoute = ImportPipepipeRouteImport.update({
   path: '/pipepipe',
   getParentRoute: () => ImportRoute,
 } as any)
+const EmbedVideoIdRoute = EmbedVideoIdRouteImport.update({
+  id: '/embed_/$videoId',
+  path: '/embed/$videoId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ChannelChannelIdRoute = ChannelChannelIdRouteImport.update({
   id: '/channel_/$channelId',
   path: '/channel/$channelId',
@@ -209,6 +215,7 @@ export interface FileRoutesByFullPath {
   '/watch-later': typeof WatchLaterRoute
   '/youtube-session': typeof YoutubeSessionRoute
   '/channel/$channelId': typeof ChannelChannelIdRoute
+  '/embed/$videoId': typeof EmbedVideoIdRoute
   '/import/pipepipe': typeof ImportPipepipeRoute
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists/$id': typeof PlaylistsIdRoute
@@ -239,6 +246,7 @@ export interface FileRoutesByTo {
   '/watch-later': typeof WatchLaterRoute
   '/youtube-session': typeof YoutubeSessionRoute
   '/channel/$channelId': typeof ChannelChannelIdRoute
+  '/embed/$videoId': typeof EmbedVideoIdRoute
   '/import/pipepipe': typeof ImportPipepipeRoute
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists/$id': typeof PlaylistsIdRoute
@@ -271,6 +279,7 @@ export interface FileRoutesById {
   '/watch-later': typeof WatchLaterRoute
   '/youtube-session': typeof YoutubeSessionRoute
   '/channel_/$channelId': typeof ChannelChannelIdRoute
+  '/embed_/$videoId': typeof EmbedVideoIdRoute
   '/import/pipepipe': typeof ImportPipepipeRoute
   '/import/youtube': typeof ImportYoutubeRoute
   '/playlists_/$id': typeof PlaylistsIdRoute
@@ -304,6 +313,7 @@ export interface FileRouteTypes {
     | '/watch-later'
     | '/youtube-session'
     | '/channel/$channelId'
+    | '/embed/$videoId'
     | '/import/pipepipe'
     | '/import/youtube'
     | '/playlists/$id'
@@ -334,6 +344,7 @@ export interface FileRouteTypes {
     | '/watch-later'
     | '/youtube-session'
     | '/channel/$channelId'
+    | '/embed/$videoId'
     | '/import/pipepipe'
     | '/import/youtube'
     | '/playlists/$id'
@@ -365,6 +376,7 @@ export interface FileRouteTypes {
     | '/watch-later'
     | '/youtube-session'
     | '/channel_/$channelId'
+    | '/embed_/$videoId'
     | '/import/pipepipe'
     | '/import/youtube'
     | '/playlists_/$id'
@@ -397,6 +409,7 @@ export interface RootRouteChildren {
   WatchLaterRoute: typeof WatchLaterRoute
   YoutubeSessionRoute: typeof YoutubeSessionRoute
   ChannelChannelIdRoute: typeof ChannelChannelIdRoute
+  EmbedVideoIdRoute: typeof EmbedVideoIdRoute
   PlaylistsIdRoute: typeof PlaylistsIdRoute
   SubscriptionsChannelsRoute: typeof SubscriptionsChannelsRoute
   AuthOidcCallbackRoute: typeof AuthOidcCallbackRoute
@@ -593,6 +606,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ImportPipepipeRouteImport
       parentRoute: typeof ImportRoute
     }
+    '/embed_/$videoId': {
+      id: '/embed_/$videoId'
+      path: '/embed/$videoId'
+      fullPath: '/embed/$videoId'
+      preLoaderRoute: typeof EmbedVideoIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/channel_/$channelId': {
       id: '/channel_/$channelId'
       path: '/channel/$channelId'
@@ -649,6 +669,7 @@ const rootRouteChildren: RootRouteChildren = {
   WatchLaterRoute: WatchLaterRoute,
   YoutubeSessionRoute: YoutubeSessionRoute,
   ChannelChannelIdRoute: ChannelChannelIdRoute,
+  EmbedVideoIdRoute: EmbedVideoIdRoute,
   PlaylistsIdRoute: PlaylistsIdRoute,
   SubscriptionsChannelsRoute: SubscriptionsChannelsRoute,
   AuthOidcCallbackRoute: AuthOidcCallbackRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -44,6 +44,7 @@ function RootLayout() {
   const pathWithSearch = `${pathname}${location.searchStr}`;
   const hideEverythingPage = pathname === "/hide-everything";
   const shortsPage = pathname === "/shorts";
+  const embedPage = pathname.startsWith("/embed/");
   const watchCinemaPage = pathname === "/watch" && cinemaMode;
   const wasWatchCinemaPage = useRef(watchCinemaPage);
   useSessionActivityReporting();
@@ -119,7 +120,7 @@ function RootLayout() {
 
   const authPage = isAuthPage(pathname);
 
-  if (instance?.guestAllowed === false && (!isAuthed || isGuest) && !authPage) {
+  if (instance?.guestAllowed === false && (!isAuthed || isGuest) && !authPage && !embedPage) {
     return <GuestDisabledScreen />;
   }
 
@@ -148,8 +149,16 @@ function RootLayout() {
     );
   }
 
+  if (embedPage) {
+    return (
+      <div className="fixed inset-0 bg-black">
+        <Outlet />
+      </div>
+    );
+  }
+
   const topPadding = { paddingTop: "calc(3.5rem + env(safe-area-inset-top, 0px))" };
-  const showTabBar = isMobile && !shortsPage && !watchCinemaPage;
+  const showTabBar = isMobile && !shortsPage && !watchCinemaPage && !embedPage;
   const mainBottomPad = showTabBar
     ? "pb-[calc(env(safe-area-inset-bottom)+4.5rem)]"
     : "pb-5 sm:pb-6";

--- a/apps/web/src/routes/embed_.$videoId.tsx
+++ b/apps/web/src/routes/embed_.$videoId.tsx
@@ -104,6 +104,9 @@ function EmbedPage() {
 
   if (!guestAllowed && !isAuthed) return <EmbedAuthRequired watchUrl={watchUrl} />;
 
+  const pending = streamQuery.isLoading || bootstrap.isLoading;
+  if (!activeStream && (!streamEnabled || pending)) return <EmbedLoading />;
+
   if (!activeStream) {
     const activeError = streamQuery.error ?? bootstrap.error;
     if (

--- a/apps/web/src/routes/embed_.$videoId.tsx
+++ b/apps/web/src/routes/embed_.$videoId.tsx
@@ -49,7 +49,7 @@ function EmbedError({ message }: { message: string }) {
   );
 }
 
-function EmbedAuthRequired({ watchUrl }: { watchUrl: string }) {
+function EmbedGuestRequired({ watchUrl }: { watchUrl: string }) {
   return (
     <div className="w-full h-full bg-black flex items-center justify-center px-4">
       <div className="flex max-w-sm flex-col items-center gap-3 rounded-xl border border-zinc-800 bg-zinc-900 px-5 py-6 text-center">
@@ -102,7 +102,7 @@ function EmbedPage() {
 
   if (instancePending || !instance) return <EmbedLoading />;
 
-  if (!guestAllowed && !isAuthed) return <EmbedAuthRequired watchUrl={watchUrl} />;
+  if (!guestAllowed && !isAuthed) return <EmbedGuestRequired watchUrl={watchUrl} />;
 
   const pending = streamQuery.isLoading || bootstrap.isLoading;
   if (!activeStream && (!streamEnabled || pending)) return <EmbedLoading />;
@@ -113,7 +113,7 @@ function EmbedPage() {
       activeError instanceof ApiError &&
       (activeError.status === 401 || activeError.status === 403)
     ) {
-      return <EmbedAuthRequired watchUrl={watchUrl} />;
+      return <EmbedGuestRequired watchUrl={watchUrl} />;
     }
     const message =
       activeError instanceof ApiError && (activeError.status === 400 || activeError.status === 422)

--- a/apps/web/src/routes/embed_.$videoId.tsx
+++ b/apps/web/src/routes/embed_.$videoId.tsx
@@ -1,0 +1,143 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { EmbedPlayerShell } from "../components/embed-player-shell";
+import { useAuth } from "../hooks/use-auth";
+import { useInstance } from "../hooks/use-instance";
+import { usePlaybackMode } from "../hooks/use-playback-mode";
+import { useSettings } from "../hooks/use-settings";
+import { MEMBER_ONLY_MESSAGE, useSabrBootstrap, useStream } from "../hooks/use-stream";
+import { ApiError } from "../lib/api";
+import { selectProgressiveWatchStream } from "../lib/progressive-watch-stream";
+import { toPublicWatchParam, toWatchSourceUrl } from "../lib/watch-url";
+
+type EmbedSearch = {
+  t?: string | number;
+  autoplay?: number;
+};
+
+function parseStartTime(raw?: string | number): number {
+  if (raw == null) return 0;
+  if (typeof raw === "number") return Math.max(0, raw);
+  const trimmed = raw.trim();
+  if (!trimmed) return 0;
+  const num = Number(trimmed);
+  if (Number.isFinite(num)) return Math.max(0, num);
+  const match = trimmed.match(/^(?:(\d+)h)?\s*(?:(\d+)m)?\s*(?:(\d+)s?)?$/);
+  if (!match) return 0;
+  const hours = Number(match[1] ?? 0);
+  const minutes = Number(match[2] ?? 0);
+  const seconds = Number(match[3] ?? 0);
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
+function EmbedLoading() {
+  return (
+    <div className="w-full h-full bg-black flex items-center justify-center">
+      <div className="aspect-video w-full max-w-[133.333vh]">
+        <div className="w-full h-full bg-black rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+function EmbedError({ message }: { message: string }) {
+  return (
+    <div className="w-full h-full bg-black flex items-center justify-center px-4">
+      <div className="flex max-w-sm flex-col items-center gap-3 rounded-xl border border-zinc-800 bg-zinc-900 px-5 py-6 text-center">
+        <p className="text-sm text-zinc-400">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function EmbedAuthRequired({ watchUrl }: { watchUrl: string }) {
+  return (
+    <div className="w-full h-full bg-black flex items-center justify-center px-4">
+      <div className="flex max-w-sm flex-col items-center gap-3 rounded-xl border border-zinc-800 bg-zinc-900 px-5 py-6 text-center">
+        <h1 className="text-base font-semibold text-white">Embed unavailable</h1>
+        <p className="text-sm text-zinc-400">
+          This instance does not allow guest access, which is required for embedded playback.
+        </p>
+        <a
+          href={watchUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 inline-flex h-9 items-center rounded-lg bg-white px-4 text-sm font-medium text-black transition-opacity hover:opacity-90"
+        >
+          Go to video
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function EmbedPage() {
+  const { videoId } = Route.useParams();
+  const { t, autoplay } = Route.useSearch();
+  const sourceUrl = toWatchSourceUrl(videoId);
+  const watchUrl = `/watch?v=${encodeURIComponent(toPublicWatchParam(sourceUrl))}`;
+  const { data: instance, isPending: instancePending } = useInstance();
+  const { authReady, isAuthed } = useAuth();
+  const { settings, settingsReady } = useSettings();
+  const { playbackMode } = usePlaybackMode();
+  const guestAllowed = instance?.guestAllowed ?? false;
+  const useAuthenticatedStream =
+    isAuthed && (settings.accessMode === "allow_list" || instance?.guestAllowed === false);
+  const streamEnabled = (guestAllowed || isAuthed) && authReady && (!isAuthed || settingsReady);
+  const streamQuery = useStream(sourceUrl, useAuthenticatedStream, streamEnabled, playbackMode);
+  const bootstrap = useSabrBootstrap(
+    sourceUrl,
+    useAuthenticatedStream,
+    streamEnabled,
+    playbackMode,
+  );
+  const publicParam = toPublicWatchParam(sourceUrl);
+  const activeStream = selectProgressiveWatchStream(
+    streamQuery.isPlaceholderData ? undefined : streamQuery.data,
+    playbackMode === "sabr" ? bootstrap.data : undefined,
+    publicParam,
+    [],
+  );
+  const startTime = parseStartTime(t) * 1000;
+  const shouldAutoplay = autoplay === 1;
+
+  if (instancePending || !instance) return <EmbedLoading />;
+
+  if (!guestAllowed && !isAuthed) return <EmbedAuthRequired watchUrl={watchUrl} />;
+
+  if (!activeStream) {
+    const activeError = streamQuery.error ?? bootstrap.error;
+    if (
+      activeError instanceof ApiError &&
+      (activeError.status === 401 || activeError.status === 403)
+    ) {
+      return <EmbedAuthRequired watchUrl={watchUrl} />;
+    }
+    const message =
+      activeError instanceof ApiError && (activeError.status === 400 || activeError.status === 422)
+        ? activeError.message
+        : "Failed to load video.";
+    return <EmbedError message={message} />;
+  }
+
+  if (activeStream.requiresMembership) {
+    return <EmbedError message={MEMBER_ONLY_MESSAGE} />;
+  }
+
+  return (
+    <EmbedPlayerShell
+      stream={activeStream}
+      sourceUrl={sourceUrl}
+      startTime={startTime}
+      autoplay={shouldAutoplay}
+      isAuthed={isAuthed}
+    />
+  );
+}
+
+export const Route = createFileRoute("/embed_/$videoId")({
+  validateSearch: (search: Record<string, unknown>): EmbedSearch => ({
+    t: typeof search.t === "string" || typeof search.t === "number" ? search.t : undefined,
+    autoplay: typeof search.autoplay === "number" ? search.autoplay : undefined,
+  }),
+  component: EmbedPage,
+});


### PR DESCRIPTION

This adds an `/embed/$videoId` endpoint for embedding the TypeType player.


My main use case is replacing embedded YT videos via the LibRedirect extension, but can be used for whatever of course. It's fully compatible with Libredirects using Invidious as frontend setting. 

Example Urls (not working on this instance for now, of course):
    YouTube: https://watch.typetype.video/embed/dQw4w9WgXcQ
    NicoNico: https://watch.typetype.video/embed/sm37617029?t=30
    BillBill: https://watch.typetype.video/embed/BV1UT42167xb?t=1m30s&autoplay=1

Since the auth token and settings live in localStorage, embedded same-origin and cross-origin work a bit differenlty.

For same-origin (opening /embed/videoid directly) works like the normal player that just fills the whole browsertab. With account and settings all being used.

For cross-origin TypeTypes localStorage isnt readable and therefor, it just uses some default settings. The server MUST have guest mode enabled for this to work, otherwise users will be redirected to the main TypeType watch page. See image below..

It also supports `?t=30` and `?autoplay=1` params and reuses the upstream `VideoPlayer`, so all the the normal player features (SABR, chapters, subtitles, quality switching etc) are working.

I actually built this over the last weekend on the pre-1.0 codebase, just to realise today, the entire architecture had been rewritten. Had to rewrite the whole thing, but the changes made it so much simpler now.


<img width="1705" height="428" alt="Screenshot_20260715_142525" src="https://github.com/user-attachments/assets/ae0f8651-3a1a-4c4c-8785-0df07ea795c1" />

Guest Mode Off: 
<img width="1676" height="384" alt="Screenshot_20260715_142624" src="https://github.com/user-attachments/assets/988b306b-46b8-47f4-b3e5-064fe72187e6" />



