### PR TITLE
fix: release TypeType 1.2.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,47 +1,19 @@
-# TypeType 1.2.1
+# TypeType 1.2.2
 
-TypeType 1.2.1 improves SABR playback stability, especially after seeks and browser lifecycle transitions. This release also includes additional recovery logic for livestreams and several mobile interface improvements.
-
-## Playback
-
-- fix Safari and iOS playback failures after SponsorBlock skips
-- prevent delayed lifecycle events from restarting an obsolete MSE playback loop after a seek
-- improve repeated, buffered and SponsorBlock seeks without unnecessarily replacing the active playback session
-- recover expired SABR sessions automatically
-- preserve media and playback state across fullscreen, Picture-in-Picture, orientation and background transitions
-- keep the same player instance while complete video metadata finishes loading
-- preserve the selected playback speed during temporary player transitions
-- update the MSE runtime to [`@typetype/mse@0.1.42`](https://www.npmjs.com/package/@typetype/mse/v/0.1.42)
+TypeType 1.2.2 is a hotpatch for YouTube livestreams that could start correctly but then buffer again every few seconds.
 
 ## Livestreams
 
-- recover bounded gaps between live SABR sequences
-- prevent repeated protected responses without media from buffering indefinitely
-- reset the recovery budget when media, playback position or generation progresses
-- improve recovery when the live playback window advances
-- preserve the active playback session during recoverable live interruptions
+- keep the server-side SABR pump active while a livestream is playing
+- maintain a bounded media buffer instead of waiting for a missing segment before requesting more data
+- wake the SABR pump immediately when the player needs another segment
+- keep audio and video windows aligned when their timestamps differ slightly
+- resolve missing live segment durations from the next available segment
+- prevent playback from incorrectly jumping over cached live media
+- preserve bounded cache eviction during long playback sessions
 
-## Mobile And PWA
+## Updating
 
-- stabilize the watch layout in mobile landscape mode
-- improve recovery after backgrounding, screen-off and orientation changes
-- preserve playback through fullscreen and Picture-in-Picture transitions
-- make history removal easier to use on touch devices
+Follow the [update guide](https://typetype-video.github.io/Docs-TypeType/self-hosting/maintenance).
 
-## Validation
-
-Playback was validated on beta with:
-
-- Safari and an installed WebKit PWA
-- a Chromium-based mobile PWA
-- automatic SponsorBlock skips
-- repeated forward and backward seeks
-- fullscreen and orientation changes
-- background, screen-off and foreground recovery
-- Picture-in-Picture transitions
-- VOD and livestream SABR playback
-- multiple fresh videos and playback sessions
-
-## Thanks
-
-Thx to @Toastienergy, @BuggyPasta, @jerkiz and @coral-hungus for the Safari, iOS and SponsorBlock reports and testing, and to @hugoghx for the detailed livestream traces.
+If necessary, follow the [rollback guide](https://typetype-video.github.io/Docs-TypeType/self-hosting/rollback).


### PR DESCRIPTION
## Summary

- prepare the TypeType 1.2.2 livestream hotpatch
- advance Server to the reviewed `1.2.2` main revision
- keep every other component on its TypeType 1.2.1 revision

## Production behavior

- keep live SABR read-ahead active while playback progresses
- wake the pump when the player reaches media that is not cached yet
- keep slightly offset audio and video windows aligned
- preserve bounded cache eviction during long livestreams
- no database schema or environment value changes

## Deployment requirements

- no database migration is required
- no environment change is required
- Server is available for AMD64 and ARM64 at `ghcr.io/typetype-video/typetype-server@sha256:6632184425f180ffa6667cfbd12c1d611f47431a130ea0f9fcfeeed1be5c1858`

## Runtime verification

- beta served Server revision `4b2666857e74d164a75e86744fe38eb448f361a6`
- a real livestream created a `299/140` SABR session and returned aligned audio and video windows
- initialization data and media segments returned successfully
- a continuation request woke the pump and became ready on the next bounded retry

## Tests

- Server `test`
- Server `check`, including OpenAPI and JaCoCo
- Server `shadowJar`
- stack validation
- `git diff --check`

## Rollback

- restore Server `sha256:e10c54c36073911cc88bf5f129bbb10de0dc2e714de92adc16ac1c3ede612c16`
- keep TypeType 1.2.1 available as the previous stable release
