### PR TITLE
fix: release TypeType 1.2.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,16 @@
-# TypeType 1.2.3
+# TypeType 1.2.4
 
-TypeType 1.2.3 is a hotpatch for accelerated YouTube playback that could exhaust SABR media windows and repeatedly restart playback.
+## Summary
 
-## Playback
+- fix intermittent SABR startup failures when resuming videos from a saved position
+- restore reliable audio and video initialization on cold playback sessions
+- prevent stalled preparation from retrying indefinitely
+- improve recovery when a SABR session cannot produce media
 
-- propagate playback speed continuously through the web SABR contract
-- size media and server read-ahead buffers for playback speeds up to 4x
-- keep rate-aware SABR preparation bounded during long sessions
-- preserve the selected video format during recovery instead of switching codec families
-- prevent repeated recovery sessions after seeks when playback is faster than the prepared window
-- update the MSE runtime to [`@typetype/mse@0.1.43`](https://www.npmjs.com/package/@typetype/mse/v/0.1.43)
+Normal seeks and quality changes continue to preserve the current playback position.
 
-## Updating
+No configuration or database migration is required.
 
-Follow the [update guide](https://typetype-video.github.io/Docs-TypeType/self-hosting/maintenance).
+Thx to everyone who reported playback and buffering issues.
 
-If necessary, follow the [rollback guide](https://typetype-video.github.io/Docs-TypeType/self-hosting/rollback).
+If u want to support TypeType, please share it with others. If u want to support it financially, u can do so through [GitHub Sponsors](https://github.com/sponsors/Priveetee).


### PR DESCRIPTION
## Summary

- prepare the TypeType 1.2.4 SABR startup hotpatch
- advance Server to the reviewed `1.2.4` main revision
- keep Frontend, Player, Downloader, Token and documentation on their TypeType 1.2.3 revisions

## Production behavior

- resumed VOD playback no longer stays in an endless SABR preparation loop
- completed livestream recordings use the VOD path during startup and quality changes
- unavailable initialization data produces a bounded recoverable failure
- normal seeks and quality changes preserve the requested playback position
- no database schema or environment value changes

## Deployment requirements

- no database migration is required
- no environment change is required
- Server is available for AMD64 and ARM64 at `ghcr.io/typetype-video/typetype-server@sha256:312d4507346afc9b8accf42bb5e06ad65487b1a90085988e6937c9f4acc0c0e5`

## Runtime verification

- beta served Server revision `07bd1cfae94815980df77264013f9b8bce2085ed`
- the final format-change classification is covered by the Server test suite
- initial playback and replacement sessions preserve VOD classification for historical livestreams

## Tests

- Server `test`
- Server `check`, including OpenAPI and JaCoCo
- Server `shadowJar`
- stack validation
- `git diff --check`

## Rollback

- restore Server `sha256:4cb61c09bd31f156e51e1eabdc71cb197ad7290f99b81f895423369dbd1a92b5`
- keep TypeType 1.2.3 available as the previous stable release
