### PR TITLE
fix: ship TypeType 1.2.4 seek hotpatch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 - restore reliable audio and video initialization on cold playback sessions
 - prevent stalled preparation from retrying indefinitely
 - improve recovery when a SABR session cannot produce media
+- keep repeated long-distance seeks responsive while SABR recovery is pending
 
 Normal seeks and quality changes continue to preserve the current playback position.
 


### PR DESCRIPTION
## Summary

- update the Frontend pin to `df97e1b2c8786aa571e29d4fe596f6844b3b67c6`
- include the repeated long-distance seek fix in the existing TypeType 1.2.4 release notes
- keep the current `1.2.4` release and image version

## Production behavior

Repeated forward and backward slider seeks remain interactive while an earlier SABR recovery request is still pending. A newer committed seek supersedes the previous request without allowing stale playback state to replace the current generation.

## Deployment requirements

Deploy the stable stack from this revision after all checks pass. The Frontend image is `ghcr.io/typetype-video/typetype@sha256:124dd7cb6161e39209b9f099238196eba05c75ab63a64f022ccbe3ae45abf052`.

No configuration or database migration is required.

## Runtime verification

Rapid long-distance seek sequences passed on Chromium, Firefox and WebKit against beta with playback resuming on the final requested position and no stale generation takeover.

## Tests

- 125 Frontend tests
- coverage verification
- Biome, Knip and Sherif checks
- production Frontend build
- multi-architecture Frontend image build and publication

## Rollback

Restore Frontend revision `9f7492cd84f593a9985d6b9c3b2d3e81d1123e42` and image `ghcr.io/typetype-video/typetype@sha256:562834d8476f02d5d6f5df5a62e6827bed2a614de85c0c231fbb797f93b36b06`.