### PR TITLE
fix: release TypeType 1.3.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,56 +1,16 @@
-> TypeType 1.3.0 brings new backup and content controls, makes SABR the only YouTube playback path on the web, and improves downloads and self-hosted updates.
+# TypeType 1.3.1
 
-## Playback
+## Summary
 
-- Use SABR/MSE for all YouTube web playback, including watch pages, embeds and autoplay. The old Classic toggle and transition prompt have been removed. NicoNico and BiliBili playback remain unchanged. [#168](https://github.com/TypeType-Video/TypeType/issues/168)
-- Recover SABR sessions when YouTube authorization expires and stop stalled preparation attempts instead of retrying indefinitely.
-- Apply automatic SponsorBlock skips in audio-only mode. [#178](https://github.com/TypeType-Video/TypeType/issues/178)
-- Add a default playback speed from `0.25x` to `4x`, applied to regular videos and Shorts.
+- fix videos and Shorts stopping after about one minute when YouTube rejects the active SABR context [#184](https://github.com/TypeType-Video/TypeType/issues/184)
+- refresh rejected YouTube token material before creating a replacement playback session
+- release replaced SABR sessions and prevent stale background work from accumulating
+- bound SABR metadata and media caches during long playback sessions
 
-## Backups And Content Controls
+Playback now recovers in place with fresh authorization instead of repeatedly creating sessions that cannot produce media.
 
-- Export a complete TypeType backup or select individual categories, including subscriptions, history, playlists, watch later, favorites, playback progress, search history, saved playlists, settings and content filters.
-- Restore versioned TypeType JSON backups with an immediate confirmation showing how many items were restored.
-- Add blocked title keywords to filter unwanted videos from recommendations.
-- Support very large history exports without exceeding PostgreSQL query limits.
-- Preserve more original dates and metadata when importing YouTube Takeout favorites, history and playlists.
+No configuration or database migration is required.
 
-## Subscriptions
-
-- Keep subscription feeds updating when one subscribed channel is deleted, private or temporarily unavailable. [#180](https://github.com/TypeType-Video/TypeType/issues/180)
-- Keep live videos ordered by their actual promotion time instead of permanently placing every active live stream first.
-
-## Downloads And Performance
-
-- Rework SABR downloads around bounded multipart streams and concurrent range workers.
-- Reserve the required disk space before starting large downloads to prevent active jobs from exhausting storage.
-- Detect stalled streams while allowing long downloads to continue as long as data is still arriving.
-- Reduce progress-update contention and reuse download buffers.
-- Serve precompressed frontend assets through Nginx.
-
-## Self-Hosting
-
-- Bundle the default Nginx configuration directly in the Frontend image.
-- Generate the default Garage configuration inside a managed Docker volume.
-- Back up existing stack files and preserve custom Compose and Garage configuration during updates.
-- Validate the resolved Compose configuration, wait for service health and provide a rollback directory when an update fails.
-- Show the Frontend, Server, Token and Downloader versions, revisions and build times directly in Settings.
-- Expand the self-hosting documentation with resource requirements and new French and Spanish prerequisites guides. [#176](https://github.com/TypeType-Video/TypeType/issues/176)
-
-Self-hosters should follow the official update procedure for this release because the Compose stack and managed configuration have changed.
-
-## Thx
-
-- A big thx to @BuggyPasta for the detailed testing and for the ideas behind backups, blocked keywords and default playback speed.
-- Thx to @Toastienergy for reporting the missing SponsorBlock behavior in audio-only mode, and to @tam1m for the precise subscription-feed report.
-- Thx to @jerkiz and @coral-hungus for testing playback and SponsorBlock on real iPhones.
-- Thx to @arcoast for the Nginx, Garage and update-flow suggestions, to @filippobaroni for helping expose problems caused by stale self-hosted stack files, and to @EdgarsJudovics for helping keep the script-free installation path documented.
-- Thx as well to everyone testing the beta, reporting playback and buffering problems, or helping other self-hosters.
-
-## Updating
-
-Follow the [update guide](https://typetype-video.github.io/Docs-TypeType/self-hosting/maintenance).
-
-If necessary, follow the [rollback guide](https://typetype-video.github.io/Docs-TypeType/self-hosting/rollback).
+Thx to @LuckeeSoft for the precise report, and to everyone who tested playback on beta.
 
 If u want to support TypeType, please share it with others. If u want to support it financially, u can do so through [GitHub Sponsors](https://github.com/sponsors/Priveetee).


### PR DESCRIPTION
## Summary

- prepare the TypeType 1.3.1 playback hotpatch
- advance Server to the reviewed `1.3.1` stable revision
- keep Frontend, Player, Downloader, Token and documentation on their TypeType 1.3.0 revisions

## Production behavior

- videos and Shorts recover when YouTube rejects the active SABR context
- replacement playback sessions receive fresh authorization material
- replaced sessions release their background work and extractor resources
- long playback sessions keep bounded SABR metadata and media caches
- no database schema or environment value changes

## Deployment requirements

- no database migration is required
- no environment change is required
- Server is available for AMD64 and ARM64 at `ghcr.io/typetype-video/typetype-server@sha256:f1ad7fd31e5c1cb994601f714df82e8207c3769d759df232e21a3876751a8faf`

## Runtime verification

- beta served Server revision `0b42a14a24f350170870efb310871ebb1fdf884b`
- reproduced [#184](https://github.com/TypeType-Video/TypeType/issues/184) at about 69 seconds before the fix
- confirmed playback recovery and continued playback beyond 168 seconds after the fix
- the browser remained at `readyState 4` with media buffered ahead and no HTTP failures

## Tests

- Server `test`
- Server `check`, including OpenAPI and JaCoCo
- Server `shadowJar`
- central stack validation
- `git diff --check`

## Rollback

- restore Server `ghcr.io/typetype-video/typetype-server@sha256:7aec72c873daad5ef8d187ba315eae2e7eb21843cabd9dd44d2552516f757a89`
- keep TypeType 1.3.0 at `536ba7dd1da99b4e554edea77559e558253886b6` as the previous stable release
