### PR TITLE
Update busybox image version to 1.38 for garage-config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
       test: ["CMD", "redis-cli", "ping"]
     restart: unless-stopped
   garage-config:
-    image: busybox:1.37
+    image: busybox:1.38
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
Stupid little thing, but we're currently pulling busybox 1.37 for typetype-secrets and 1.38 for garage-config