### PR TITLE
Update garage-config busybox version to 1.38  to match typetype-secrets

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -149,7 +149,7 @@ services:
     restart: unless-stopped
 
   garage-config:
-    image: busybox:1.37
+    image: busybox:1.38
     command:
       - /bin/sh
       - -ec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
       test: ["CMD", "redis-cli", "ping"]
     restart: unless-stopped
   garage-config:
-    image: busybox:1.37
+    image: busybox:1.38
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
New PR to `dev` branch to update `garage-config` busybox base image ref [here](https://github.com/TypeType-Video/TypeType/pull/220)