### PR TITLE
fix: release TypeType 1.7.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,57 +1,21 @@
-# TypeType 1.7.0
+# TypeType 1.7.1
 
-TypeType 1.7.0 adds account portability, community localization, subscription-group groundwork and a more resilient SABR playback path.
+TypeType 1.7.1 is a focused Server hotfix for SABR playback stalls after resuming or seeking in VOD videos.
 
 ## Playback
 
-- Restore saved playback positions before SABR startup instead of beginning at `00:00`.
-- Update TypeType-Player to MSE `0.1.56` with more stable buffered seeks and source transitions.
-- Stream VOD SABR media progressively and reuse bootstrap preparation to reduce startup and seek work.
-- Align VOD audio windows to the current playhead and keep playback generations isolated during seeks.
-- Prefer the original audio language when the source exposes it. [#249](https://github.com/TypeType-Video/TypeType/issues/249)
-- Reduce redundant progress requests and avoid blocking playback on cached progress updates.
-- Improve loading/session transitions and startup buffering while the remaining runtime reports continue to be monitored. [#238](https://github.com/TypeType-Video/TypeType/issues/238) [#248](https://github.com/TypeType-Video/TypeType/issues/248)
+- Continue filling progressive VOD playback windows across every readable segment instead of stopping after the first one.
+- Prevent resumed and distant seeks from remaining stuck in repeated SABR preparation cycles while media is already available.
+- Preserve bounded preparation, playback generation isolation and the existing retry behavior.
+- Update TypeType-Server to `1.7.1`. [PR #82](https://github.com/TypeType-Video/TypeType-Server/pull/82)
 
-## Account Portability
-
-- Add asynchronous account import and export with owned jobs, progress and diagnostics.
-- Support TypeType, PipePipe, NewPipe, Invidious, Piped, LibreTube, ViewTube, Materialious, Flow, SkyTube, Grayjay, YouTube Takeout and OPML data.
-- Add the import workspace and preview flow in the web application.
-- Keep portability format detection and category writes bounded and deterministic.
-
-## Localization
-
-- Add the frontend translation catalog and English/French runtime messages. [#246](https://github.com/TypeType-Video/TypeType/issues/246)
-- Add a Weblate workflow so contributors can translate without changing application code.
-- Cover navigation, settings, player, watch, administration, authentication and portability surfaces.
-- Unify and slightly speed up the language transition animation across the application.
-- Use the Lucide `Pin` icon for pinned comments.
-- Add checks that prevent new untranslated frontend literals from being introduced.
-
-## Subscription Groups
-
-- Add named subscription-group membership endpoints, including bounded atomic batch updates. [#172](https://github.com/TypeType-Video/TypeType/issues/172) [PR #80](https://github.com/TypeType-Video/TypeType-Server/pull/80)
-- Preserve idempotent single-item compatibility while supporting multi-group channel membership.
-- Add a TypeType management preview for filters, ungrouped channels, search, multi-select and inline group creation.
-- Keep channels optional: nobody is required to assign every subscription to a group.
-
-## Downloads And Reliability
-
-- Preserve downloader artifact response metadata, including `Content-Length`. [#240](https://github.com/TypeType-Video/TypeType/issues/240)
-- Keep the authenticated Server gateway in front of downloader artifacts.
-- Serialize remote YouTube login input events so pointer press/release order is preserved. [#250](https://github.com/TypeType-Video/TypeType/issues/250)
-
-No configuration change or manual database migration is required for this release.
+No frontend change, configuration change or manual database migration is required.
 
 ## Thx
 
-A huge thx to @kapdon for implementing the subscription-group Server contract and for the careful work on batching, locking and tests. [PR #80](https://github.com/TypeType-Video/TypeType-Server/pull/80)
-
-Thx to [@typetype-translations](https://github.com/typetype-translations) and everyone contributing translations through Weblate. [#246](https://github.com/TypeType-Video/TypeType/issues/246)
+Thx to everyone who reported buffering and seek regressions and shared detailed playback logs.
 
 A special thx to sponsors [@Toastienergy](https://github.com/Toastienergy) and [@filippobaroni](https://github.com/filippobaroni) for supporting TypeType.
-
-Thx as well to everyone testing the beta, reporting playback and buffering problems, sharing logs, improving the documentation and helping other self-hosters.
 
 ## Updating
 


### PR DESCRIPTION
## Summary

- publish the TypeType 1.7.1 hotfix notes
- advance the TypeType-Server pin to the reviewed 1.7.1 merge revision
- keep every other component pinned to its existing 1.7.0 revision

## Production behavior

- progressive VOD playback windows continue across every readable segment
- resumed and distant seeks no longer stop after the first readable segment
- bounded preparation, retry behavior and playback generation isolation remain unchanged

## Deployment requirements

No frontend change, configuration change or manual database migration is required.

The stable multi-architecture Server image is published at `ghcr.io/typetype-video/typetype-server@sha256:c33675e2665314c0f86dca1bd75e24170e0beff2a50f1e878494b9bbf20d8438`.

## Runtime verification

- public instance reports Server 1.7.1 at revision `8ac0d25a90d5`
- playback starts and advances normally on the affected VOD path
- a distant seek becomes playable in under one second and continues for at least 20 seconds
- the buffered range continues growing after the seek
- no failed browser request, media error or fatal Server log was observed

## Tests

- Server PR #82: tests, OpenAPI validation, JaCoCo, shadow JAR and Docker images
- stable Server `amd64/arm64` manifest validation
- central `scripts/validate-stack.sh`
- `git diff --check`

Component and central CI remain the final release gates.

## Rollback

- restore the TypeType-Server pointer to `feaa1d76ea5c`
- restore the previous stable Server image digest `sha256:33bce2a45f7ae1931d290ee6d6e91a97ba4fd542aa61b07fca532f2b978a757b`
- no database rollback is required
