### PR TITLE
fix: release TypeType 1.7.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,19 +1,19 @@
-# TypeType 1.7.1
+# TypeType 1.7.2
 
-TypeType 1.7.1 is a focused Server hotfix for SABR playback stalls after resuming or seeking in VOD videos.
+TypeType 1.7.2 is a focused Token hotfix for YouTube videos that stopped starting after an anonymous playback identity was rejected.
 
 ## Playback
 
-- Continue filling progressive VOD playback windows across every readable segment instead of stopping after the first one.
-- Prevent resumed and distant seeks from remaining stuck in repeated SABR preparation cycles while media is already available.
-- Preserve bounded preparation, playback generation isolation and the existing retry behavior.
-- Update TypeType-Server to `1.7.1`. [PR #82](https://github.com/TypeType-Video/TypeType-Server/pull/82)
+- Detect anonymous YouTube `LOGIN_REQUIRED` responses during MWEB and WEB SABR session creation.
+- Discard the rejected Innertube and BotGuard identity before obtaining fresh visitor-bound and video-bound PO-token material.
+- Retry session creation once with the new identity while preserving bounded recovery behavior.
+- Update TypeType-Token to `1.7.2`. [PR #16](https://github.com/TypeType-Video/TypeType-Token/pull/16)
 
 No frontend change, configuration change or manual database migration is required.
 
 ## Thx
 
-Thx to everyone who reported buffering and seek regressions and shared detailed playback logs.
+Thx to everyone who reported videos failing to start and shared detailed playback diagnostics.
 
 A special thx to sponsors [@Toastienergy](https://github.com/Toastienergy) and [@filippobaroni](https://github.com/filippobaroni) for supporting TypeType.
 


### PR DESCRIPTION
## Summary

- publish the TypeType 1.7.2 hotfix notes
- advance the TypeType-Token pin to the reviewed 1.7.2 merge revision
- keep every other component pinned to its existing release revision

## Production behavior

- rejected anonymous YouTube playback identities are discarded
- fresh BotGuard and PO-token material is generated before retrying
- SABR session creation remains bounded to one identity rotation

## Deployment requirements

No frontend change or manual database migration is required. The stable Token image is `ghcr.io/typetype-video/typetype-token@sha256:05d7323290cc7b0354b4f4e7d5f8e3123aed31fc78e4a480b856cc92655da253`.

The public instance also stopped routing YouTube traffic through the rejected IPv6 egress path.

## Runtime verification

- the public instance runs Token 1.7.2 at revision `888e91d1c26b`
- repeated public SABR bootstrap checks returned complete sessions for the three affected videos and the control video
- Chromium playback advanced continuously for two affected videos with `readyState` 4, growing buffered ranges, no media error and no failed SABR request
- Token and Server remained healthy, with no `LOGIN_REQUIRED`, failure or exception in their post-rollout logs

## Tests

- Token PR #16: 99 tests, lint, type checks, build and dependency audit
- isolated real-network Token probes for four public VODs
- stable multi-architecture image publication
- `git diff --check`

## Rollback

- restore the TypeType-Token pointer to `87c6e7e4a3d8`
- restore the previous stable Token image digest `sha256:18e425d86ca299be89c80fbff3e4d7bd0ae549d3bbc092347bc6d76ca0202a28`
- restore the previous production environment from the recorded deployment backup
- no database rollback is required
